### PR TITLE
Fixed typo in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "DataTables": "~1.10.5",
     "leaflet.elevation": "MrMufflon/Leaflet.Elevation#master",
     "leaflet-control-geocoder": "~1.1.0",
-    "L.EasyButton": "*",
+    "Leaflet.EasyButton": "*",
     "bootbox": "~4.4.0",
     "seiyria-bootstrap-slider": "~4.8.1"
   },


### PR DESCRIPTION
Changed dependency `L.EasyButton` to `Leaflet.EasyButton` so
`bower install` completes successfully. `L.EasyButton` is not
available on bower.