### PR TITLE
Fix elevation chart offset when hiding/showing it on Chrome-based browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
         </div>
     </div>
 
-    <div id="content">
+    <div id="content" class="flexcolumn">
         <div id="map"></div>
 
         <div id="message"></div>


### PR DESCRIPTION
Sorry for the time taken, but this was a painful bug to fix because I didn't have a clue about what was going on - I finally was able to track the problem to this simple one class missing attribute! Fix first todo of #66.