### PR TITLE
car-eco/fast + display energy/time

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,7 +19,8 @@
         BR.conf.profiles = [
             'trekking',
             'fastbike',
-            'car-test',
+            'car-eco',
+            'car-fast',
             'safety',
             'shortest',
             'trekking-ignore-cr',
@@ -48,7 +49,8 @@
             'fastbike',
             'shortest',
             'moped',
-            'car-test'
+            'car-eco',
+            'car-fast'
         ];
 
         BR.conf.host = 'http://localhost:17777';

--- a/js/control/TrackStats.js
+++ b/js/control/TrackStats.js
@@ -14,14 +14,27 @@ BR.TrackStats = BR.Control.extend({
             length1 = L.Util.formatNum(stats.trackLength/1000,1),
             length3 = L.Util.formatNum(stats.trackLength/1000,3),
             meanCostFactor = stats.trackLength ? L.Util.formatNum(stats.cost / stats.trackLength, 2) : '',
+            formattedTime = L.Util.formatNum(stats.totalTime / 60., 1),
+            formattedEnergy = L.Util.formatNum(stats.totalEnergy / 3600000., 2),
+            meanEnergy = stats.trackLength ? L.Util.formatNum(stats.totalEnergy / 36. / stats.trackLength, 2) : '',
             html = '';
 
         html += '<table id="stats">';
         html += '<tr><td>Length: </td><td title="' + length3 + ' km">' + length1 + '</td><td>km</td></tr>';
-        html += '<tr><td>Ascent filtered:</td><td>' + stats.filteredAscend + '</td><td>m</td></tr>';
-        html += '<tr><td>Ascent plain:</td><td>' + stats.plainAscend + '</td><td>m</td></tr>';
-        html += '<tr><td>Cost: </td><td>' + stats.cost + '</td><td></td></tr>';
-        html += '<tr><td>Mean cost:</td><td>' + meanCostFactor + '</td><td></td></tr>';
+        if ( stats.totalTime )
+        {
+          html += '<tr><td>Time:</td><td>' + formattedTime + '</td><td>min</td></tr>';
+          html += '<tr><td>Energy:</td><td>' + formattedEnergy + '</td><td>kWh</td><td><small>&nbsp;(mean: ' + meanEnergy + ')</small></td></tr>';
+          html += '<tr><td>Ascent:</td><td>' + stats.filteredAscend + '</td><td>m</td><td><small>&nbsp;(plain: ' + stats.plainAscend + ')</small></td></tr>';
+          html += '<tr><td>Cost: </td><td>' + stats.cost + '</td><td></td><td><small>&nbsp;(mean: ' + meanCostFactor + ')</small></td></tr>';
+        }
+        else
+        {
+          html += '<tr><td>Ascent filtered:</td><td>' + stats.filteredAscend + '</td><td>m</td></tr>';
+          html += '<tr><td>Ascent plain:</td><td>' + stats.plainAscend + '</td><td>m</td></tr>';
+          html += '<tr><td>Cost: </td><td>' + stats.cost + '</td><td></td></tr>';
+          html += '<tr><td>Mean cost:</td><td>' + meanCostFactor + '</td><td></td></tr>';
+        }
         html += '</table>'; 
 
         this._content.innerHTML = html;
@@ -32,6 +45,8 @@ BR.TrackStats = BR.Control.extend({
             trackLength: 0,
             filteredAscend: 0,
             plainAscend: 0,
+            totalTime: 0,
+            totalEnergy: 0,
             cost: 0
         };
         var i, props;
@@ -41,6 +56,8 @@ BR.TrackStats = BR.Control.extend({
             stats.trackLength += +props['track-length'];
             stats.filteredAscend += +props['filtered ascend'];
             stats.plainAscend += +props['plain-ascend'];
+            stats.totalTime += +props['total-time'];
+            stats.totalEnergy += +props['total-energy'];
             stats.cost += +props['cost'];
         }
 


### PR DESCRIPTION
This is a 0.6 patch to display travel-time + energy, as available for the new car-profiles in brouter 1.4.9

Is also replaces the car-test -profile by car-eco + car-fast

GUI change is restricted to the case that travel time is available. Re-arranged all trackstat-lines to stick to a 5 lines layout