### PR TITLE
Add leaflet strava segments (work in progress)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,13 +24,15 @@
     "seiyria-bootstrap-slider": "^9.8.1",
     "url-search-params": "~0.5.0",
     "Leaflet.RestoreView": "makinacorpus/Leaflet.RestoreView#master",
+    "leaflet.stravasegments": "bagage/leaflet.stravasegments#master",
     "leaflet.locatecontrol": "^0.60.0",
     "font-awesome": "^4.7.0",
     "bootstrap-select": "hugdx/bootstrap-select#patch-1",
     "leaflet-sidebar-v2": "nrenner/leaflet-sidebar-v2#dev",
     "leaflet.editable": "^1.1.0",
     "codemirror": "^5.35.0",
-    "mapbbcode": "MapBBCode/mapbbcode#v1.2.0"
+    "mapbbcode": "MapBBCode/mapbbcode#v1.2.0",
+    "@mapbox/polyline": "^0.2.0"
   },
   "overrides": {
     "leaflet": {

--- a/config.template.js
+++ b/config.template.js
@@ -125,4 +125,7 @@
         ];
 
     }
+
+    // Strava API token in case you want to display Strava segments
+    BR.conf.stravaToken = null;
 })();

--- a/js/index.js
+++ b/js/index.js
@@ -240,6 +240,14 @@
         drawToolbar = L.easyBar([drawButton, nogos.getButton(), deleteButton]).addTo(map);
         nogos.preventRoutePointOnCreate(routing);
 
+        if (BR.conf.stravaToken) {
+            new L.Control.StravaSegments(
+            {
+                stravaToken: BR.conf.stravaToken
+            })
+            .addTo(map);
+        }
+
         map.addControl(new BR.OpacitySlider({
             callback: L.bind(routing.setOpacity, routing)
         }));


### PR DESCRIPTION
I've developed a leaflet plugin to display [Strava segments](https://support.strava.com/hc/en-us/articles/216918167-Strava-Segments) on the map. Apart of helping Strava users find segments near them, it allows to find interesting ways around you even for non-Strava users:

![image](https://user-images.githubusercontent.com/1451988/44946355-2db47d80-adfb-11e8-992b-da35ed91c7f2.png)

If Strava API public is not set, buttons won't be added on the interface. WDYT?