### PR TITLE
Fix release script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -229,7 +229,7 @@ gulp.task('release:zip', ['release:tag', 'default'], function() {
 });
 
 gulp.task('release:publish', ['release:zip'], function() {
-  gulp.src('./brouter-web-'+nextVersion+'.zip')
+  gulp.src('./brouter-web.'+nextVersion+'.zip')
   .pipe(release({
     tag: nextVersion,
     token: ghToken,


### PR DESCRIPTION
Regression since 7f4a0bf, the zip file has been renamed but it is not uploaded to github automatically anymore.