### PR TITLE
Downgrade leaflet to 1.3.X

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "leaflet": "^1.3.3",
+    "leaflet": "~1.3.0",
     "leaflet-plugins": "~3.0.0",
     "leaflet-routing": "nrenner/leaflet-routing#dev",
     "async": "~0.9.2",


### PR DESCRIPTION
In leaflet 1.4.0 (https://github.com/Leaflet/Leaflet/commit/19d9e3bc93072bac655b9c6c28737442a6afe7fc), `L.control.layers._form` was renamed `L.control.layers._section`. We are using it in [LayersTab](https://github.com/nrenner/brouter-web/blob/master/js/control/LayersTab.js#L5).

I did not rename it but instead fixed Leaflet version to 1.3.X because do not know what are the other changes in Leaflet 1.4.X.

~~I've also updated LeafletSegment dependencies due to recent developments.~~ see #152