### PR TITLE
Render polygons from URL hash and pass it to BRouter server

### DIFF
--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -114,7 +114,9 @@ BR.NogoAreas = L.Control.extend({
 
     getOptions: function() {
         return {
-            nogos: this.drawnItems.getLayers()
+            nogos: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Circle; }),
+            polygons: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Polygon; }),
+            polylines: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Polyline; }),
         };
     },
 

--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -17,7 +17,7 @@ BR.NogoAreas = L.Control.extend({
         fillOpacity: 0.2,
         dashArray: null
     },
-    
+
     editStyle: {
  				color: '#fe57a1',
 				opacity: 0.6,
@@ -31,7 +31,7 @@ BR.NogoAreas = L.Control.extend({
 
     onAdd: function (map) {
         var self = this;
-        
+
         this.drawnItems = new L.FeatureGroup().addTo(map);
         this.drawnItems.on('click', function(e) {
             L.DomEvent.stop(e);
@@ -109,7 +109,7 @@ BR.NogoAreas = L.Control.extend({
                     routing.draw(true);
                 }, 0);
             }
-        }, this);       
+        }, this);
     },
 
     getOptions: function() {
@@ -120,11 +120,25 @@ BR.NogoAreas = L.Control.extend({
 
     setOptions: function(options) {
         var nogos = options.nogos;
+        var polylines = options.polylines;
+        var polygons = options.polygons;
         this._clear();
         if (nogos) {
             for (var i = 0; i < nogos.length; i++) {
                 nogos[i].setStyle(this.style);
                 this.drawnItems.addLayer(nogos[i]);
+            }
+        }
+        if (polylines) {
+            for (var i = 0; i < polylines.length; i++) {
+                polylines[i].setStyle(this.style);
+                this.drawnItems.addLayer(polylines[i]);
+            }
+        }
+        if (polygons) {
+            for (var i = 0; i < polygons.length; i++) {
+                polygons[i].setStyle(this.style);
+                this.drawnItems.addLayer(polygons[i]);
             }
         }
     },
@@ -141,15 +155,15 @@ BR.NogoAreas = L.Control.extend({
     _fireUpdate: function () {
         this.fire('update', {options: this.getOptions()});
     },
-    
+
     getFeatureGroup: function() {
         return this.drawnItems;
     },
-    
+
     getEditGroup: function() {
         return this.editTools.editLayer;
     },
-    
+
     getButton: function() {
         return this.button;
     }
@@ -175,7 +189,7 @@ BR.EditingTooltip = L.Handler.extend({
     },
 
     addHooks: function () {
-        // hack: listen to EasyButton click (instead of editable:drawing:start), 
+        // hack: listen to EasyButton click (instead of editable:drawing:start),
         // to get mouse position from event for initial tooltip location
         L.DomEvent.addListener(this.button.button, 'click', this._addCreate, this);
 
@@ -197,7 +211,7 @@ BR.EditingTooltip = L.Handler.extend({
     },
 
     _bind: function (e) {
-        // Position tooltip at bottom of circle, less distracting than 
+        // Position tooltip at bottom of circle, less distracting than
         // sticky with cursor or at center.
 
         var layer = e.layer;
@@ -206,7 +220,7 @@ BR.EditingTooltip = L.Handler.extend({
             className: 'editing-tooltip'
         });
 
-        // Override to set position to south instead of center (circle latlng); 
+        // Override to set position to south instead of center (circle latlng);
         // works better with zooming than updating offset to match radius
         layer.openTooltip = function (layer, latlng) {
             if (!latlng && layer instanceof L.Layer) {
@@ -219,7 +233,7 @@ BR.EditingTooltip = L.Handler.extend({
     _addCreate: function (e) {
         // button cancel
         if (!this.editTools.drawing()) return;
-        
+
         var initialLatLng = this.map.mouseEventToLatLng(e);
         var tooltip = L.tooltip({
             // no effect with map tooltip
@@ -256,7 +270,7 @@ BR.EditingTooltip = L.Handler.extend({
             this.map.closeTooltip(tooltip);
         };
         this.editTools.once('editable:editing editable:drawing:cancel', closeTooltip, this);
-        
+
         if (BR.Browser.touch) {
             // can't move with cursor on touch devices, so show at start pos for a few seconds
             setTimeout(L.bind(closeTooltip, this), this.options.closeTimeout);
@@ -267,7 +281,7 @@ BR.EditingTooltip = L.Handler.extend({
         var timeoutId = setTimeout(function () {
            layer.closeTooltip();
         }, this.options.closeTimeout);
-        
+
         // prevent timer to close tooltip that changed in the meantime
         layer.once('tooltipopen', function (e) {
            clearTimeout(timeoutId);
@@ -286,7 +300,7 @@ BR.EditingTooltip = L.Handler.extend({
 
     _enable: function (e) {
         e.layer.setTooltipContent(BR.NogoAreas.MSG_ENABLED);
-        
+
         this.editTools.once('editable:editing', function(e) {
             e.layer.closeTooltip();
         }, this);
@@ -353,7 +367,7 @@ BR.DeletableCircleEditor = L.Editable.CircleEditor.extend({
     onDrawingMouseDown: function (e) {
         this._deleteLatLng.update(e.latlng);
         L.Editable.CircleEditor.prototype.onDrawingMouseDown.call(this, e);
-    }, 
+    },
 
     // override to cancel/remove created circle when added by click instead of drag, because:
     // - without resize, edit handles stacked on top of each other

--- a/js/router/BRouter.js
+++ b/js/router/BRouter.js
@@ -282,6 +282,10 @@ L.BRouter = L.Class.extend({
                 }
                 s += this._formatLatLng(vertices[j]);
             }
+            if (polyline.options.nogoWeight) {
+                s += L.BRouter.NUMBER_SEPARATOR;
+                s += polyline.options.nogoWeight;
+            }
             if (i < (nogos.length - 1)) {
                 s += L.BRouter.GROUP_SEPARATOR;
             }
@@ -304,9 +308,15 @@ L.BRouter = L.Class.extend({
                 latlngs = [];
                 for (var j = 0; j < numbers.length - 1;)
                 {
-                    latlngs.push([numbers[j++], numbers[j++]]);
+                    var lng = Number.parseFloat(numbers[j++]);
+                    var lat = Number.parseFloat(numbers[j++]);
+                    latlngs.push([lat, lng]);
                 }
-                nogos.push(L.polyline(latlngs));
+                var nogoWeight;
+                if (j < numbers.length) {
+                    nogoWeight = Number.parseFloat(numbers[j++]);
+                }
+                nogos.push(L.polyline(latlngs, { nogoWeight: nogoWeight }));
             }
         }
         return nogos;
@@ -322,6 +332,10 @@ L.BRouter = L.Class.extend({
                     s += L.BRouter.NUMBER_SEPARATOR;
                 }
                 s += this._formatLatLng(vertices[j]);
+            }
+            if (polygon.options.nogoWeight) {
+                s += L.BRouter.NUMBER_SEPARATOR;
+                s += polygon.options.nogoWeight;
             }
             if (i < (nogos.length - 1)) {
                 s += L.BRouter.GROUP_SEPARATOR;
@@ -345,9 +359,15 @@ L.BRouter = L.Class.extend({
                 latlngs = [];
                 for (var j = 0; j < numbers.length - 1;)
                 {
-                    latlngs.push([numbers[j++], numbers[j++]]);
+                    var lng = Number.parseFloat(numbers[j++]);
+                    var lat = Number.parseFloat(numbers[j++]);
+                    latlngs.push([lat, lng]);
                 }
-                nogos.push(L.polygon(latlngs));
+                var nogoWeight;
+                if (j < numbers.length) {
+                    nogoWeight = Number.parseFloat(numbers[j++]);
+                }
+                nogos.push(L.polygon(latlngs, { nogoWeight: nogoWeight }));
             }
         }
         return nogos;


### PR DESCRIPTION
Hi,

Here is a small increment to my previous work on supporting polygons in BRouter-web.

Polygons are now parsed from URL, rendered and correctly passed to the latest `master` version of BRouter.

![screenshot_2019-02-18 brouter web client](https://user-images.githubusercontent.com/3856586/52974355-82f04580-33c1-11e9-8369-9c61fd294c05.png)

You can try this using `BROUTER_WEB_URL/#map=17/48.82463/2.33347/OpenStreetMap&lonlats=2.331714,48.823734|2.336258,48.824221&polygons=2.332106,48.823579,2.33556,48.823579,2.33556,48.824342,2.332106,48.824342,10`.

There are still some things left to do afterwards:

- [ ] The possibility to draw and edit the polygons as well as their weight. I'm not sure I can help a lot on this, I don't know much about the Leaflet plugin currently used :/
- [ ] I'd like to have the possibility to import a GeoJSON file of nogo areas. This is useful to import an OpenData file of roadworks for instance. I think I can work on this if you think this is something worth having.

Best,