### PR TITLE
i18n: translate website

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+minimum_perc = 1
+lang_map = fr_CA:fr-CA,pt_BR:pt-BR,zh_CN:zh-CN,zh_HK:zh-HK,zh_TW:zh-TW,da_DK:da-DK,sv_SE:sv-SE,kn_IN:kn-IN,nl_NL:nl-NL,en_NL:en-NL,gl_ES:gl-ES
+
+[brouter-web.brouter-website]
+file_filter = locales/<lang>.json
+source_file = locales/en.json
+source_lang = en
+type = JSON

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ http://brouter.de
 General BRouter discussions/questions, support:  
 https://groups.google.com/group/osm-android-bikerouting
 
+## Translating
+
+Translations are managed using the
+[Transifex](https://www.transifex.com/openstreetmap/brouter-web/) platform. After
+signing up, you can go to [BRouter's project
+page](https://www.transifex.com/openstreetmap/brouter-web/dashboard/), select a language and
+click **Translate** to start translating.
+
+<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<script type="text/javascript" src="https://www.transifex.com/_/charts/js/openstreetmap/brouter-web/inc_js/brouter-website/"></script>
+<div id="txchart-brouter-web-brouter-website">Loading chart...</div>
+
 ## Installation
 
 As an alternative to the above online version, the standalone server of BRouter can also be run on your local desktop.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-    <title>BRouter web client</title>
+    <title data-i18n="title">BRouter web client</title>
 
     <!-- inject:css -->
     <link rel="stylesheet" href="dist/brouter-web.css" />
@@ -25,29 +25,32 @@
                     <div class="form-group">
                         <select class="selectpicker show-tick" data-width="250px" id="profile-alternative" multiple>
                             <optgroup label="Profile" data-max-options="1" data-icon="fa-bicycle" id="profile">
-                                <option>Custom</option>
+                                <option data-i18n="navbar.profile.custom">Custom</option>
                             </optgroup>
                             <optgroup label="Alternative" data-max-options="1" data-icon="fa-random" id="alternative">
-                                <option value="0" selected>Original</option>
-                                <option value="1">1st alternative</option>
-                                <option value="2">2nd alternative</option>
-                                <option value="3">3rd alternative</option>
+                                <option data-i18n="navbar.alternative.original" value="0" selected>Original</option>
+                                <option data-i18n="navbar.alternative.first" value="1">1st alternative</option>
+                                <option data-i18n="navbar.alternative.second" value="2">2nd alternative</option>
+                                <option data-i18n="navbar.alternative.third" value="3">3rd alternative</option>
                             </optgroup>
                         </select>
                     </div>
                 </form>
                 <div class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                        <span class="fa fa-lg fa-cloud-download" aria-hidden="true"></span>Download</a>
+                        <span class="fa fa-lg fa-cloud-download" aria-hidden="true">
+                        </span>
+                        <span data-i18n="navbar.download.title">Download</span>
+                    </a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item" id="dl-gpx" href="#" disabled>GPX</a>
-                        <a class="dropdown-item" id="dl-kml" href="#" disabled>KML</a>
-                        <a class="dropdown-item" id="dl-geojson" href="#" disabled>GeoJSON</a>
-                        <a class="dropdown-item" id="dl-csv" href="#" disabled>data CSV</a>
+                        <a class="dropdown-item" data-i18n="navbar.download.gpx" id="dl-gpx" href="#" disabled>GPX</a>
+                        <a class="dropdown-item" data-i18n="navbar.download.kml" id="dl-kml" href="#" disabled>KML</a>
+                        <a class="dropdown-item" data-i18n="navbar.download.geojson" id="dl-geojson" href="#" disabled>GeoJSON</a>
+                        <a class="dropdown-item" data-i18n="navbar.download.csv" id="dl-csv" href="#" disabled>data CSV</a>
                     </div>
                 </div>
                 <div class="nav-item">
-                  <a class="nav-link" href="#" data-toggle="modal" data-target="#about"><span class="fa fa-lg fa-info-circle" aria-hidden="true"></span>About</a>
+                  <a class="nav-link" href="#" data-toggle="modal" data-target="#about"><span class="fa fa-lg fa-info-circle" aria-hidden="true"></span><span data-i18n="navbar.about">About</span></a>
                 </div>
             </div>
         </div>
@@ -61,51 +64,51 @@
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
-                    <h4 class="modal-title">Credits</h4>
+                    <h4 class="modal-title" data-i18n="credits">Credits</h4>
                 </div>
                 <div class="modal-body">
                     <dl>
-                        <dt>Map data</dt>
-                        <dd>
-                            &copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>
-                            under <a target="_blank" href="https://opendatacommons.org/licenses/odbl/">ODbL</a>
+                        <dt data-i18n="credits.map-data">Map data</dt>
+                        <dd data-i18n="[html]credits.openstreetmap">
+                            &copy; <a target="_blank" href="https://www.openstreetmap.org/copyright" >OpenStreetMap contributors</a>
+                            under <a target="_blank" href="https://opendatacommons.org/licenses/odbl/" >ODbL</a>
                         </dd>
-                        <dd>
+                        <dd data-i18n="[html]credits.nominatim">
                             Search by <a href="https://wiki.openstreetmap.org/wiki/Nominatim" target="_blank">Nominatim</a>
                         </dd>
-                        <dt>OpenStreetMap tiles</dt>
-                        <dd>
+                        <dt data-i18n="credits.osm-tiles">OpenStreetMap tiles</dt>
+                        <dd data-i18n="[html]credits.osm-license">
                             <a target="_blank" href="https://www.openstreetmap.org/copyright">openstreetmap.org</a> 
                             under <a target="_blank" href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA 2.0</a>
                         </dd>
-                        <dt>OpenStreetMap.de tiles</dt>
+                        <dt data-i18n="credits.osmde-tiles">OpenStreetMap.de tiles</dt>
                         <dd>
                             <a target="_blank" href="https://openstreetmap.de/karte.html">openstreetmap.de</a>
                         </dd>
-                        <dt>OpenTopoMap tiles</dt>
-                        <dd>
+                        <dt data-i18n="credits.opentopomap-tiles">OpenTopoMap tiles</dt>
+                        <dd data-i18n="[html]credits.opentopomap-license">
                             &copy; <a target="_blank" href="https://opentopomap.org">OpenTopoMap</a>
                             under <a target="_blank" href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>
                             <a target="_blank" href="http://viewfinderpanoramas.org">SRTM</a>
                         </dd>
-                        <dt>OpenCycleMap & Outdoors tiles</dt>
-                        <dd>
+                        <dt data-i18n="credits.opencyclemap-outdoors-tiles">OpenCycleMap & Outdoors tiles</dt>
+                        <dd data-i18n="[html]credits.thunderforest-license">
                             &copy; <a target="_blank" href="https://www.thunderforest.com">Thunderforest</a>
                             under <a target="_blank" href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA 2.0</a>
                         </dd>
-                        <dt>Esri World Imagery</dt>
-                        <dd>
+                        <dt data-i18n="credits.esri-tiles">Esri World Imagery</dt>
+                        <dd data-i18n="[html]credits.esri-license">
                             <a target="_blank" href="http://goto.arcgisonline.com/maps/World_Imagery">World Imagery</a> 
                             &copy; <a target="_blank" href="https://www.esri.com/">Esri</a>, sources: 
                             Esri, DigitalGlobe, Earthstar Geographics, CNES/Airbus DS, GeoEye, USDA FSA, USGS, Getmapping, Aerogrid, IGN, IGP, and the GIS User Community
                         </dd>
-                        <dt>Cycling & Hiking tiles</dt>
-                        <dd>
+                        <dt data-i18n="credits.cycling-hiking-tiles">Cycling & Hiking tiles</dt>
+                        <dd data-i18n="[html]credits.waymarked-license">
                             &copy; <a target="_blank" href="https://cycling.waymarkedtrails.org">Waymarked Trails</a>
                             under <a target="_blank" href="https://creativecommons.org/licenses/by-sa/3.0/de/deed.en">CC-BY-SA 3.0 DE</a>
                         </dd>
-                        <dt>BRouter</dt>
-                        <dd>
+                        <dt data-i18n="credits.brouter">BRouter</dt>
+                        <dd data-i18n="[html]credits.brouter-license">
                             <a target="_blank" href="http://brouter.de/brouter">BRouter</a> &copy; Arndt Brenschede
                         </dd>
                     </dl>
@@ -122,15 +125,15 @@
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
-                    <h4 class="modal-title">Customize layers</h4>
+                    <h4 class="modal-title" data-i18n="layers.customize">Customize layers</h4>
                 </div>
                 <div class="modal-body">
-                    <input class="form-control" type="text" id="layer_name" spellcheck="true" wrap="off" placeholder="Custom layer name. (ex: OpenStreetMap)"></input>
-                    <input class="form-control" type="text" id="layer_url" spellcheck="false" wrap="off" placeholder="Custom layer URL. (ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)"></input>
+                    <input class="form-control" type="text" id="layer_name" spellcheck="true" wrap="off" data-i18n="[placeholder]layers.placeholder-layer-name"  placeholder="Custom layer name. (ex: OpenStreetMap)"></input>
+                    <input class="form-control" type="text" id="layer_url" spellcheck="false" wrap="off" data-i18n="[placeholder]layers.placeholder-layer-url" placeholder="Custom layer URL. (ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)"></input>
 
-                    <button type="button" id="custom_layers_add_base" class="btn btn-success">Add base layer</button>
-                    <button type="button" id="custom_layers_add_overlay" class="btn btn-success">Add overlay</button>
-                    <button type="button" id="custom_layers_remove" class="btn btn-danger">Remove selection</button>
+                    <button type="button" id="custom_layers_add_base" class="btn btn-success" data-i18n="layers.add-base">Add base layer</button>
+                    <button type="button" id="custom_layers_add_overlay" class="btn btn-success" data-i18n="layers.add-overlay">Add overlay</button>
+                    <button type="button" id="custom_layers_remove" class="btn btn-danger" data-i18n="layers.remove-selection">Remove selection</button>
                     <table id="custom_layers_table"></table>
                 </div>
             </div>
@@ -145,25 +148,25 @@
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
-                    <h4 class="modal-title">About</h4>
+                    <h4 class="modal-title" data-i18n="about.title">About</h4>
                 </div>
                 <div class="modal-body">
-                    <p>Online service of the BRouter routing engine. For the offline Android app and more information
+                    <p data-i18n="[html]about.description">Online service of the BRouter routing engine. For the offline Android app and more information
                         see <a href="http://brouter.de/" target="_blank">brouter.de</a>.</p>
                     <p>
-                        <i>Contact:</i><br>
+                        <i data-i18n="about.contact">Contact:</i><br>
                         <ul>
-                            <li>General discussions/questions, support:<br>
+                            <li><span data-i18n="about.support">General discussions/questions, support:</span><br>
                                 <a href="https://groups.google.com/group/osm-android-bikerouting" target="_blank">https://groups.google.com/group/osm-android-bikerouting</a>
                             </li>
-                            <li>Bug reports and feature requests:
+                            <li><span data-i18n="about.bug-reports">Bug reports and feature requests:</span>
                                 <ul>
                                     <li>
-                                        server / backend, routing engine, Android app, profiles, brouter.de site:<br>
+                                        <span data-i18n="about.bug-reports-back">server / backend, routing engine, Android app, profiles, brouter.de site:</span><br>
                                         <a href="https://github.com/abrensch/brouter/issues" target="_blank">https://github.com/abrensch/brouter/issues</a>
                                     </li>
                                     <li>
-                                        web client / frontend:<br>
+                                        <span data-i18n="about.bug-reports-front">web client / frontend:</span><br>
                                         <a href="https://github.com/nrenner/brouter-web/issues" target="_blank">https://github.com/nrenner/brouter-web/issues</a>
                                     </li>
                                 </ul>
@@ -171,11 +174,13 @@
                         </ul>
                     </p>
                     <p>
-                        <i>Data:</i><br>
-                        This is based on <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a>. It is usually updated once a week when a new Planet file is available,
-                        see dates of <a href="http://brouter.de/brouter/segments4/" target="_blank">data files</a>.
+                        <i data-i18n="about.data">Data:</i>
+                        <div data-i18n="[html]about.data-description">
+                            This is based on <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a>. It is usually updated once a week when a new Planet file is available,
+                            see dates of <a href="http://brouter.de/brouter/segments4/" target="_blank">data files</a>.
+                        </div>
                     </p>
-                    <p>
+                    <p data-i18n="[html]about.details">
                         <i><a href="http://brouter.de/privacypolicy.html" target="_blank">Privacy Policy</a></i>, 
                         <i><a href="https://github.com/nrenner/brouter-web#credits-and-licenses" target="_blank">Credits</a></i>,
                         <i><a href="https://github.com/nrenner/brouter-web/blob/master/CHANGELOG.md" target="_blank">Changelog</a></i> and
@@ -189,7 +194,7 @@
     <div id="content" class="flexcolumn flexgrow">
         <div id="sidebarTabs" class="leaflet-sidebar-tabs collapsed">
             <ul role="tablist">
-                <li><a href="#tab_layers_control" role="tab" title="Layers">
+                <li><a href="#tab_layers_control" role="tab" data-i18n="[title]sidebar.layers.title" title="Layers">
                         <!--
                         https://github.com/feathericons/feather/blob/0dc2bf5c9d01759e47485d9498aefc02cac1d845/icons/layers.svg
                         MIT License: https://github.com/feathericons/feather/blob/master/LICENSE
@@ -201,9 +206,9 @@
                             <polyline points="2 16 12 21 22 16"></polyline>
                         </svg>
                     </a></li>
-                <li hidden><a href="#tab_itinerary" role="tab" title="Itinerary"><i class="fa fa-map-signs"></i></a></li>
-                <li><a href="#tab_profile" role="tab" title="Custom profile"><i class="fa fa-wrench"></i></a></li>
-                <li><a href="#tab_data" role="tab" title="Data"><i class="fa fa-table"></i></a></li> 
+                <li hidden><a href="#tab_itinerary" role="tab" data-i18n="[title]sidebar.itinerary.title" title="Itinerary"><i class="fa fa-map-signs"></i></a></li>
+                <li><a href="#tab_profile" role="tab" data-i18n="[title]sidebar.custom-profile.title" title="Custom profile"><i class="fa fa-wrench"></i></a></li>
+                <li><a href="#tab_data" role="tab" data-i18n="[title]sidebar.data.title" title="Data"><i class="fa fa-table"></i></a></li> 
             </ul>
         </div>
         
@@ -216,34 +221,34 @@
 
                 <div class="leaflet-sidebar-content">
                     <div class="leaflet-sidebar-pane" id="tab_layers_control">
-                        <h1 class="leaflet-sidebar-header"><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span>Layers</h1>
+                        <h1 class="leaflet-sidebar-header"><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span data-i18n="sidebar.layers.title">Layers</span></h1>
                         <div id="layers-control-wrapper"></div>
                         <div class="leaflet-control-layers-separator"></div>
                         <div>
-                            <button type="button" id="custom_layers_button" class="btn btn-sm pull-right" title="Add or remove custom layers"><span class="fa fa-plus-square"></span> Custom layers</button>
+                            <button type="button" id="custom_layers_button" class="btn btn-sm pull-right" data-i18n="[title]sidebar.layers.customize" title="Add or remove custom layers"><span class="fa fa-plus-square"></span> <span data-i18n="sidebar.layers.custom-layers">Custom layers</span></button>
                         </div>
                     </div>
 
                     <div class="leaflet-sidebar-pane" id="tab_profile">
-                        <h1 class="leaflet-sidebar-header"><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span class="leaflet-sidebar-expand"><i class="fa fa-expand"></i></span>Custom profile</h1>
+                        <h1 class="leaflet-sidebar-header"><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span class="leaflet-sidebar-expand"><i class="fa fa-expand"></i></span><span data-i18n="sidebar.custom-profile.title">Custom profile</span></h1>
                         <form class="flexcolumn flexgrow">
-                            <textarea class="form-control flexgrow" id="profile_upload" spellcheck="false" wrap="off" placeholder="Write your custom profile here."></textarea>
+                            <textarea class="form-control flexgrow" id="profile_upload" spellcheck="false" wrap="off" data-i18n="[placeholder]sidebar.profile.placeholder" placeholder="Write your custom profile here."></textarea>
                             <div id="profile_message"></div>
                             <div class="form-group" id="profile_buttons">
-                                 <button id="upload" type="button" class="btn btn-sm" data-uploading-text="Uploading…"><span class="fa fa-cloud-upload"></span> Upload</button>
-                                 <button id="clear" type="button" class="btn btn-sm"><span class="fa fa-eraser"></span> Clear</button>
-                                 <a href="http://brouter.de/brouter/costfunctions.html" target="_blank" class="btn btn-sm btn-info pull-right"><span class="fa fa-question"></span> Help</a>
+                                 <button id="upload" type="button" class="btn btn-sm" data-uploading-text="Uploading…"><span class="fa fa-cloud-upload"></span> <span data-i18n="sidebar.profile.upload">Upload</span></button>
+                                 <button id="clear" type="button" class="btn btn-sm"><span class="fa fa-eraser"></span> <span data-i18n="sidebar.profile.clear">Clear</span></button>
+                                 <a href="http://brouter.de/brouter/costfunctions.html" target="_blank" class="btn btn-sm btn-info pull-right"><span class="fa fa-question"></span> <span data-i18n="sidebar.profile.help">Help</span></a>
                             </div>
                         </form>
                     </div>
 
                     <div class="leaflet-sidebar-pane" id="tab_data">
-                        <h1 class="leaflet-sidebar-header"><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span class="leaflet-sidebar-expand"><i class="fa fa-expand"></i></span>Data</h1>
+                        <h1 class="leaflet-sidebar-header"><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span class="leaflet-sidebar-expand"><i class="fa fa-expand"></i></span><span data-i18n="sidebar.data.title">Data</span></h1>
                         <table id="datatable" class="mini cell-border hover stripe"></table>
                     </div>
 
                     <div class="leaflet-sidebar-pane" id="tab_itinerary">
-                        <h1 class="leaflet-sidebar-header">Itinerary<span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span class="leaflet-sidebar-expand"><i class="fa fa-expand"></i></span></h1>
+                        <h1 class="leaflet-sidebar-header"><span data-i18n="sidebar.itinerary.title">Itinerary</span><span class="leaflet-sidebar-close"><i class="fa fa-caret-right"></i></span><span class="leaflet-sidebar-expand"><i class="fa fa-expand"></i></span></h1>
                         <div id="itinerary" class="flexcolumn flexgrow">
                         </div>
                     </div>
@@ -259,23 +264,23 @@
         <div class="flexrow">
             <ul id="stats">
                 <li>
-                    <div class="text-muted small hidden-sm-down">Distance</div>
-                    <p class="stats-label"><span id="distance">0</span> <abbr title="kilometer">km</abbr></p>
+                    <div class="text-muted small hidden-sm-down" data-i18n="footer.distance">Distance</div>
+                    <p class="stats-label"><span id="distance">0</span> <abbr data-i18n="[title]footer.kilometer;footer.kilometer-abbrev" title="kilometer">km</abbr></p>
                 </li>
                 <li hidden>
-                    <div class="text-muted small hidden-sm-down">Travel time</div>
-                    <p class="stats-label"><span id="totaltime">0</span> <abbr title="minutes">min</abbr></p>
+                    <div class="text-muted small hidden-sm-down" data-i18n="footer.travel-time">Travel time</div>
+                    <p class="stats-label"><span id="totaltime">0</span> <abbr data-i18n="[title]footer.minutes;footer.minutes-abbrev" title="minutes">min</abbr></p>
                 </li>
                 <li hidden>
-                    <div class="text-muted small hidden-sm-down">Total Energy (per 100km)</div>
-                    <p class="stats-label"><span id="totalenergy">0 (0)</span> <abbr title="kilowatt hour">kWh</abbr></p>
+                    <div class="text-muted small hidden-sm-down" data-i18n="footer.total-energy">Total Energy (per 100km)</div>
+                    <p class="stats-label"><span id="totalenergy">0 (0)</span> <abbr data-i18n="[title]footer.kilowatthour;footer.kilowatthour-abbrev" title="kilowatt hour">kWh</abbr></p>
                 </li>
                 <li>
-                    <div class="text-muted small hidden-sm-down">Ascend (Plain ascend)</div>
-                    <p class="stats-label"><span id="ascend">0 (0)</span> <abbr title="meter">m</abbr></p>
+                    <div class="text-muted small hidden-sm-down" data-i18n="footer.ascend">Ascend (Plain ascend)</div>
+                    <p class="stats-label"><span id="ascend">0 (0)</span> <abbr data-i18n="[title]footer.meter;footer.meter-abbrev" title="meter">m</abbr></p>
                 </li>
                 <li>
-                    <div class="text-muted small hidden-sm-down">Cost (Mean cost factor)</div>
+                    <div class="text-muted small hidden-sm-down" data-i18n="footer.cost">Cost (Mean cost factor)</div>
                     <p class="stats-label"><span id="cost">- (-)</span></p>
                 </li>
             </ul>

--- a/js/Map.js
+++ b/js/Map.js
@@ -45,65 +45,67 @@ BR.Map = {
             maxNativeZoom: 19,
             maxZoom: maxZoom,
             subdomains: ['server', 'services'],
-            attribution: '<a target="_blank" href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9">Esri World Imagery</a>'
+            attribution: '<a target="_blank" href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9">' + i18next.t('credits.esri-tiles') + '</a>'
         });
 
         var cycling = L.tileLayer('https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png', {
           maxNativeZoom: 18,
           opacity: 0.7,
           maxZoom: maxZoom,
-          attribution: '<a target="_blank" href="http://cycling.waymarkedtrails.org/#?map={zoom}!{lat}!{lon}">Cycling</a>'
+          attribution: '<a target="_blank" href="http://cycling.waymarkedtrails.org/#?map={zoom}!{lat}!{lon}">' + i18next.t('map.cycling') + '</a>'
         });
         var hiking = L.tileLayer('https://tile.waymarkedtrails.org/hiking/{z}/{x}/{y}.png', {
           maxNativeZoom: 18,
           opacity: 0.7,
           maxZoom: maxZoom,
-          attribution: '<a target="_blank" href="http://hiking.waymarkedtrails.org/#?map={zoom}!{lat}!{lon}">Hiking</a>'
+          attribution: '<a target="_blank" href="http://hiking.waymarkedtrails.org/#?map={zoom}!{lat}!{lon}">' + i18next.t('map.hiking') + '</a>'
         });
 
         map = new L.Map('map', {
+            zoomControl: false, // add it manually so that we can translate it
             worldCopyJump: true
         });
+        L.control.zoom({
+            zoomInTitle: i18next.t('map.zoomInTitle'),
+            zoomOutTitle: i18next.t('map.zoomOutTitle'),
+        }).addTo(map);
         if (!map.restoreView()) {
             map.setView([50.99, 9.86], 6);
         }
 
         // two attribution lines by adding two controls, prevents ugly wrapping on
         // small screens, better separates static from layer-specific attribution
+        var osmAttribution = $(map.getContainer()).outerWidth() >= 400 ? i18next.t('map.attribution-osm-long') : i18next.t('map.attribution-osm-short');
         map.attributionControl.setPrefix(
-            '&copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>' +
-            ($(map.getContainer()).outerWidth() >= 400 ? ' contributers' : '') +
-            ' &middot; <a href="" data-toggle="modal" data-target="#credits">Copyright</a>' +
-            ' &middot; <a target="_blank" href="http://brouter.de/privacypolicy.html">Privacy</a>');
+            '&copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">' + osmAttribution + '</a>' +
+            ' &middot; <a href="" data-toggle="modal" data-target="#credits">' + i18next.t('map.copyright') + '</a>' +
+            ' &middot; <a target="_blank" href="http://brouter.de/privacypolicy.html">' + i18next.t('map.privacy') + '</a>');
 
         new L.Control.PermalinkAttribution().addTo(map);
         map.attributionControl.setPrefix(false);
 
-        var baseLayers = {
-            'OpenStreetMap': osm,
-            'OpenStreetMap.de': osmde,
-            'OpenTopoMap': topo,
-            'OpenCycleMap (Thunderf.)': cycle,
-            'Outdoors (Thunderforest)': outdoors,
-            'Esri World Imagery': esri
-        };
-        var overlays = {
-             'Cycling (Waymarked Trails)': cycling,
-             'Hiking (Waymarked Trails)': hiking
-        };
+        var baseLayers = {}
+        baseLayers[i18next.t('map.layer.osm')] = osm;
+        baseLayers[i18next.t('map.layer.osmde')] = osmde;
+        baseLayers[i18next.t('map.layer.topo')] = topo;
+        baseLayers[i18next.t('map.layer.cycle')] = cycle;
+        baseLayers[i18next.t('map.layer.outdoors')] = outdoors;
+        baseLayers[i18next.t('map.layer.esri')] = esri;
+        var overlays = {}
+        overlays[i18next.t('map.layer.cycling')] = cycling;
+        overlays[i18next.t('map.layer.hiking')] = hiking;
 
         if (BR.keys.bing) {
-            baseLayers['Bing Aerial'] = new BR.BingLayer(BR.keys.bing);
+            baseLayers[i18next.t('map.layer.bing')] = new BR.BingLayer(BR.keys.bing);
         }
 
         if (BR.keys.digitalGlobe) {
             var recent = new L.tileLayer('https://{s}.tiles.mapbox.com/v4/digitalglobe.nal0g75k/{z}/{x}/{y}.png?access_token=' + BR.keys.digitalGlobe, {
                 minZoom: 1,
                 maxZoom: 19,
-                attribution: '&copy; <a href="https://www.digitalglobe.com/platforms/mapsapi">DigitalGlobe</a> ('
-                           + '<a href="https://bit.ly/mapsapiview">Terms of Use</a>)'
+                attribution: i18next.t('credits.digitalglobe-license')
             });
-            baseLayers['DigitalGlobe Recent Imagery'] = recent;
+            baseLayers[i18next.t('map.layer.digitalglobe')] = recent;
         }
 
         if (BR.conf.clearBaseLayers) {
@@ -131,6 +133,9 @@ BR.Map = {
         var secureContext = 'isSecureContext' in window ? isSecureContext : location.protocol === 'https:';
         if (secureContext) {
             L.control.locate({
+                strings: {
+                    title: i18next.t('map.locate-me')
+                },
                 icon: 'fa fa-location-arrow',
                 iconLoading: 'fa fa-spinner fa-pulse',
             }).addTo(map);

--- a/js/Util.js
+++ b/js/Util.js
@@ -22,7 +22,7 @@ BR.Util = {
     },
 
     getError: function(xhr) {
-        var msg = 'no response from server';
+        var msg = i18next.t('warning.no-response');
         if (xhr.responseText) {
           msg = xhr.responseText;
         } else if (xhr.status || xhr.statusText) {

--- a/js/control/Layers.js
+++ b/js/control/Layers.js
@@ -25,10 +25,13 @@ BR.Layers = L.Class.extend({
             info: false,
             searching: false,
             paging: false,
+            language: {
+                emptyTable: i18next.t("sidebar.layers.table.empty")
+            },
             columns: [
-            { title: "Name" },
-            { title: "URL" },
-            { title: "Type" }
+                { title: i18next.t("sidebar.layers.table.name") },
+                { title: i18next.t("sidebar.layers.table.URL") },
+                { title: i18next.t("sidebar.layers.table.type") }
             ]
         });
     },

--- a/js/control/Message.js
+++ b/js/control/Message.js
@@ -37,7 +37,7 @@ BR.Message = L.Class.extend({
 
     showError: function (err) {
         if (err == 'Error: target island detected for section 0\n') {
-            err = 'Error: cannot find a route for given points. Maybe try to move them closer to roads?';
+            err = i18next.t('warning.no-route-found');
         }
         this._show(err, 'error');
     },

--- a/js/control/OpacitySlider.js
+++ b/js/control/OpacitySlider.js
@@ -28,7 +28,7 @@ BR.OpacitySlider = L.Control.extend({
         };
 
         $(container).html(input);
-        $(container).attr('title', 'Set transparency of route track and markers');
+        $(container).attr('title', i18next.t('map.opacity-slider'));
 
         input.slider({
             min: 0,

--- a/js/control/RoutingOptions.js
+++ b/js/control/RoutingOptions.js
@@ -9,7 +9,7 @@ BR.RoutingOptions = L.Evented.extend({
         for (var i = 0; i < profiles.length; i++) {
             var option = document.createElement("option");
             option.value = profiles[i];
-            option.text = profiles[i];
+            option.text = i18next.t("navbar.profile." + profiles[i]);
             profiles_list.appendChild(option);
         }
         // set default value, used as indicator for empty custom profile 

--- a/js/index.js
+++ b/js/index.js
@@ -59,7 +59,7 @@
                     routing.draw(false);
                     control.state('activate-draw');
                 },
-                title: 'Stop drawing route (ESC key)'
+                title: i18next.t('map.draw-route-stop')
             }, {
                 stateName: 'activate-draw',
                 icon: 'fa-pencil',
@@ -67,7 +67,7 @@
                     routing.draw(true);
                     control.state('deactivate-draw');
                 },
-                title: 'Draw route (D key)'
+                title: i18next.t('map.draw-route-start')
             }]
         });
 
@@ -76,11 +76,11 @@
             function () {
                 bootbox.prompt({
                     size: 'small',
-                    title: "Delete route?",
+                    title: i18next.t('map.delete-route'),
                     inputType: 'checkbox',
                     inputOptions: [
                         {
-                            text: '&nbsp;&nbsp;also delete all no-go areas',
+                            text: i18next.t('map.delete-nogo-areas'),
                             value: 'nogo'
                         }
                     ],
@@ -96,7 +96,7 @@
                     }
                 });
             },
-            'Clear route'
+            i18next.t('map.clear-route')
         );
 
         function updateRoute(evt) {
@@ -122,6 +122,11 @@
             profile.update(evt.options);
         });
 
+        BR.NogoAreas.MSG_BUTTON = i18next.t("map.nogo.draw");
+        BR.NogoAreas.MSG_BUTTON_CANCEL = i18next.t("map.nogo.cancel");
+        BR.NogoAreas.MSG_CREATE = i18next.t("map.nogo.click-drag");
+        BR.NogoAreas.MSG_DISABLED = i18next.t("map.nogo.edit");
+        BR.NogoAreas.MSG_ENABLED = i18next.t("map.nogo.help");
         nogos = new BR.NogoAreas();
         nogos.on('update', updateRoute);
 
@@ -145,8 +150,7 @@
                         options: routingOptions.getOptions()
                     });
                     if (!saveWarningShown) {
-                        profile.message.showWarning('<strong>Note:</strong> Uploaded custom profiles are only cached temporarily on the server.'
-                            + '<br/>Please save your edits to your local PC.');
+                        profile.message.showWarning(i18next.t('warning.temporary-profile'));
                         saveWarningShown = true;
                     }
                 } else {
@@ -241,12 +245,14 @@
         nogos.preventRoutePointOnCreate(routing);
 
         if (BR.keys.strava) {
-            const stravaControl = new L.Control.StravaSegments(
-            {
+            const stravaControl = L.control.stravaSegments({
+                runningTitle: i18next.t('map.strava-running'),
+                bikingTitle: i18next.t('map.strava-biking'),
+                loadingTitle: i18next.t('map.loading'),
                 stravaToken: BR.keys.strava
             })
             .addTo(map);
-            layersControl.addOverlay(stravaControl.stravaLayer, "Strava segments");
+            layersControl.addOverlay(stravaControl.stravaLayer, i18next.t('map.layer.strava-segments'));
         }
 
         map.addControl(new BR.OpacitySlider({
@@ -352,8 +358,20 @@
                       });
     }
 
-    mapContext = BR.Map.initMap();
-    verifyTouchStyle(mapContext);
-    initApp(mapContext);
+    i18next
+        .use(window.i18nextXHRBackend)
+        .use(window.i18nextBrowserLanguageDetector)
+        .init({
+            fallbackLng: 'en',
+            backend: {
+                loadPath: 'locales/{{lng}}.json',
+            }
+        }, function(err, t) {
+            jqueryI18next.init(i18next, $);
+            $('html').localize();
 
+            mapContext = BR.Map.initMap();
+            verifyTouchStyle(mapContext);
+            initApp(mapContext);
+        });
 })();

--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -4,7 +4,7 @@ BR.NogoAreas = L.Control.extend({
         MSG_BUTTON_CANCEL: 'Cancel drawing no-go area',
         MSG_CREATE: 'Click and drag to draw circle',
         MSG_DISABLED: 'Click to edit',
-        MSG_ENABLED: '&square; = move / resize, <span class="fa fa-trash-o"></span> = delete,<br>click nogo to quit editing',
+        MSG_ENABLED: '&square; = move / resize, <span class="fa fa-trash-o"></span> = delete,<br>click circle to quit editing',
         STATE_CREATE: 'no-go-create',
         STATE_CANCEL: 'cancel-no-go-create'
     },
@@ -116,9 +116,7 @@ BR.NogoAreas = L.Control.extend({
         return {
             nogos: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Circle; }),
             polygons: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Polygon; }),
-            polylines: this.drawnItems.getLayers().filter(function (e) {
-                return (e instanceof L.Polyline) && !(e instanceof L.Polygon);
-            }),
+            polylines: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Polyline; }),
         };
     },
 
@@ -228,10 +226,7 @@ BR.EditingTooltip = L.Handler.extend({
         // works better with zooming than updating offset to match radius
         layer.openTooltip = function (layer, latlng) {
             if (!latlng && layer instanceof L.Layer) {
-                latlng = L.latLng(
-                    layer.getBounds().getSouth(),
-                    0.5 * (layer.getBounds().getWest() + layer.getBounds().getEast())
-                );
+                latlng = L.latLng(layer.getBounds().getSouth(), layer.getLatLng().lng);
             }
             L.Layer.prototype.openTooltip.call(this, layer, latlng);
         };

--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -4,7 +4,7 @@ BR.NogoAreas = L.Control.extend({
         MSG_BUTTON_CANCEL: 'Cancel drawing no-go area',
         MSG_CREATE: 'Click and drag to draw circle',
         MSG_DISABLED: 'Click to edit',
-        MSG_ENABLED: '&square; = move / resize, <span class="fa fa-trash-o"></span> = delete,<br>click circle to quit editing',
+        MSG_ENABLED: '&square; = move / resize, <span class="fa fa-trash-o"></span> = delete,<br>click nogo to quit editing',
         STATE_CREATE: 'no-go-create',
         STATE_CANCEL: 'cancel-no-go-create'
     },
@@ -116,7 +116,9 @@ BR.NogoAreas = L.Control.extend({
         return {
             nogos: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Circle; }),
             polygons: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Polygon; }),
-            polylines: this.drawnItems.getLayers().filter(function (e) { return e instanceof L.Polyline; }),
+            polylines: this.drawnItems.getLayers().filter(function (e) {
+                return (e instanceof L.Polyline) && !(e instanceof L.Polygon);
+            }),
         };
     },
 
@@ -226,7 +228,10 @@ BR.EditingTooltip = L.Handler.extend({
         // works better with zooming than updating offset to match radius
         layer.openTooltip = function (layer, latlng) {
             if (!latlng && layer instanceof L.Layer) {
-                latlng = L.latLng(layer.getBounds().getSouth(), layer.getLatLng().lng);
+                latlng = L.latLng(
+                    layer.getBounds().getSouth(),
+                    0.5 * (layer.getBounds().getWest() + layer.getBounds().getEast())
+                );
             }
             L.Layer.prototype.openTooltip.call(this, layer, latlng);
         };

--- a/js/router/BRouter.js
+++ b/js/router/BRouter.js
@@ -125,7 +125,7 @@ L.BRouter = L.Class.extend({
             xhr = new XMLHttpRequest();
 
         if (!url) {
-            return cb(new Error('Error getting route URL'));
+            return cb(new Error(i18next.t('warning.cannot-get-route')));
         }
 
         xhr.open('GET', url, true);
@@ -179,7 +179,7 @@ L.BRouter = L.Class.extend({
         xhr.onload = L.bind(this._handleProfileResponse, this, xhr, cb);
         xhr.onerror = function(evt) {
             var xhr = this;
-            cb('Upload error: ' + xhr.statusText);
+            cb(i18next.t('warning.upload-error', {error: xhr.statusText}));
         };
 
         // send profile text only, as text/plain;charset=UTF-8
@@ -193,7 +193,7 @@ L.BRouter = L.Class.extend({
             response = JSON.parse(xhr.responseText);
             cb(response.error, response.profileid);
         } else {
-            cb('Profile error: no or empty response from server');
+            cb(i18next.t('warning.profile-error'));
         }
     },
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,171 @@
+{
+  "about": {
+    "bug-reports": "Fehlerberichte und Funktionsanfragen:",
+    "bug-reports-back": "Server / Backend, Routing Engine, Android-App, Profile, brouter.de Website",
+    "bug-reports-front": "Web-Client / Frontend:",
+    "contact": "Kontakt:",
+    "data": "Daten:",
+    "data-description": "Dies basiert auf <a href=\"https://www.openstreetmap.org\" target=\"_blank\">OpenStreetMap</a>. Es wird normalerweise einmal pro Woche aktualisiert, wenn ein neues Planet-File verfügbar ist. Siehe Datum von<a href=\"http://brouter.de/brouter/segments4/\" target=\"_blank\">data files</a>.",
+    "description": "Online-Service der BRouter Routing Engine. Für die Offline-Android-App und weitere Informationen siehe <a href=\"http://brouter.de/\" target=\"_blank\">brouter.de</a>.",
+    "details": "<i><a href=\"http://brouter.de/privacypolicy.html\" target=\"_blank\">Datenschutz-Bestimmungen</a></i>,\n<i><a href=\"https://github.com/nrenner/brouter-web#credits-and-licenses\" target=\"_blank\">Credits</a></i>,\n<i><a href=\"https://github.com/nrenner/brouter-web/blob/master/CHANGELOG.md\" target=\"_blank\">Änderungsprotokoll</a></i> und\n<i><a href=\"https://github.com/nrenner/brouter-web#readme\" target=\"_blank\">weitere Infos</a></i> zum Client.",
+    "support": "Generelle Diskussionen/Fragen, Support:",
+    "title": "Über"
+  },
+  "credits": {
+    "brouter": "BRouter",
+    "brouter-license": "<a target=\"_blank\" href=\"http://brouter.de/brouter\">BRouter</a> &copy; Arndt Brenschede",
+    "cycling-hiking-tiles": "Fahrrad- und Wander tiles",
+    "digitalglobe-license": "&copy; <a href=\"https://www.digitalglobe.com/platforms/mapsapi\">DigitalGlobe</a> (<a href=\"https://bit.ly/mapsapiview\">Terms of Use</a>)",
+    "esri-license": "<a target=\"_blank\" href=\"http://goto.arcgisonline.com/maps/World_Imagery\">World Imagery</a> &copy; <a target=\"_blank\" href=\"https://www.esri.com/\">Esri</a>, Quellen: Esri, DigitalGlobe, Earthstar Geographics, CNES/Airbus DS, GeoEye, USDA FSA, USGS, Getmapping, Aerogrid, IGN, IGP und die GIS Benutzergemeinschaft",
+    "esri-tiles": "Esri World Imagery",
+    "map-data": "Kartendaten",
+    "nominatim": "Suchen mit <a href=\"https://wiki.openstreetmap.org/wiki/Nominatim\" target=\"_blank\" data-i18n=\"credits.nominatim\">Nominatim</a>",
+    "opencyclemap-outdoors-tiles": "OpenCycleMap & Outdoors tiles",
+    "openstreetmap": "&copy; <a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\" >OpenStreetMap contributors</a> unter <a target=\"_blank\" href=\"https://opendatacommons.org/licenses/odbl/\" >ODbL</a>",
+    "opentopomap-license": "&copy; <a target=\"_blank\" href=\"https://opentopomap.org\">OpenTopoMap</a> unter <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a> <a target=\"_blank\" href=\"http://viewfinderpanoramas.org\">SRTM</a>",
+    "opentopomap-tiles": "OpenTopoMap tiles",
+    "osm-license": "<a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\">openstreetmap.org</a> unter <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "osm-tiles": "OpenStreetMap tiles",
+    "osmde-tiles": "OpenStreetMap.de tiles",
+    "thunderforest-license": "&copy; <a target=\"_blank\" href=\"https://www.thunderforest.com\">Thunderforest</a> unter <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "waymarked-license": "&copy; <a target=\"_blank\" href=\"https://cycling.waymarkedtrails.org\">Waymarked Trails</a> unter <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/de/deed.en\">CC-BY-SA 3.0 DE</a>"
+  },
+  "footer": {
+    "ascend": "Aufsteigend (einfach aufsteigend)",
+    "cost": "Kosten (durchschnittlicher Kostenfaktor)",
+    "distance": "Entfernung",
+    "kilometer": "Kilometer",
+    "kilometer-abbrev": "km",
+    "kilowatthour": "Kilowattstunden",
+    "kilowatthour-abbrev": "kWh",
+    "meter": "Meter",
+    "meter-abbrev": "m",
+    "minutes": "Minuten",
+    "minutes-abbrev": "min",
+    "total-energy": "Gesamtenergie (pro 100 km)",
+    "travel-time": "Reisezeit"
+  },
+  "layers": {
+    "add-base": "Basisebene hinzufügen",
+    "add-overlay": "Overlay hinzufügen",
+    "customize": "Ebenen anpassen",
+    "placeholder-layer-name": "angepasster Ebenenname (Bsp: OpenStreetMap)",
+    "placeholder-layer-url": "angepasste Ebenen-URL (Bsp: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)",
+    "remove-selection": "Auswahl entfernen"
+  },
+  "map": {
+    "attribution-osm-long": "OpenStreetMap Mitarbeiter",
+    "attribution-osm-short": "OpenStreetMap",
+    "clear-route": "Route löschen",
+    "copyright": "Copyright",
+    "cycling": "Radfahren",
+    "delete-nogo-areas": "&nbsp;&nbsp;auch alle no-go areas löschen",
+    "delete-route": "Route löschen?",
+    "draw-route-start": "Route anzeigen (D Taste)",
+    "draw-route-stop": "Stoppen der Routenanzeige (ESC Taste)",
+    "hiking": "Wandern",
+    "layer": {
+      "bing": "Bing Luftbild",
+      "cycle": "OpenCycleMap (Thunderf.)",
+      "cycling": "Radfahren (markierte Routen)",
+      "digitalglobe": "DigitalGlobe neueste Bilder",
+      "esri": "Esri Weltbilder",
+      "hiking": "Wandern (markierte Routen)",
+      "osm": "OpenStreetMap",
+      "osmde": "OpenStreetMap.de",
+      "outdoors": "Outdoor (Thunderforest)",
+      "strava-segments": "Strava Segmente",
+      "topo": "OpenTopoMap"
+    },
+    "loading": "Laden ...",
+    "locate-me": "Zeige meinen Standort",
+    "nogo": {
+      "cancel": "Anzeigen der no-go area abbrechen",
+      "click-drag": "Klicken und ziehen zum Zeichnen eines Kreises",
+      "draw": "no-go area zeichnen (Kreis)",
+      "edit": "Klicken zum Bearbeiten",
+      "help": "&square; = Bewegen / Größe anpassen, <span class=\"fa fa-trash-o\"></span> = Löschen,<br>Kreis anklicken um Bearbeiten zu beenden"
+    },
+    "opacity-slider": "Transparenz von Route und Markern anpassen",
+    "privacy": "Datenschutz",
+    "strava-biking": "Zeige Strava Radfahrsegmente",
+    "strava-running": "Zeige Strava Läufersegmente",
+    "zoomInTitle": "Hineinzoomen",
+    "zoomOutTitle": "Herauszoomen"
+  },
+  "navbar": {
+    "about": "Über",
+    "alternative": {
+      "first": "1. Alternative",
+      "original": "Original",
+      "second": "2. Alternative",
+      "third": "3. Alternative"
+    },
+    "download": {
+      "csv": "CSV Daten",
+      "geojson": "GeoJSON",
+      "gpx": "GPX",
+      "kml": "KML",
+      "title": "Download"
+    },
+    "profile": {
+      "car-eco": "Auto (ökonomisch)",
+      "car-fast": "Auto (schnell)",
+      "car-test": "Auto (Test)",
+      "custom": "Benutzerdefiniert",
+      "fastbike": "schnelles Rad",
+      "fastbike-asia-pacific": "schnelles Rad (Asien Pazifik)",
+      "fastbike-lowtraffic": "schnelles Rad wenig Verkehr",
+      "hiking-beta": "Wandern (beta)",
+      "moped": "Moped",
+      "rail": "Zug",
+      "river": "Fluss",
+      "safety": "Sicherste",
+      "shortest": "Kürzeste",
+      "trekking": "Wandern",
+      "trekking-ignore-cr": "Wandern (Radrouten ignorieren)",
+      "trekking-noferries": "Wandern (keine Fähren)",
+      "trekking-nosteps": "Wandern (keine Treppen)",
+      "trekking-steep": "Wandern steil",
+      "vm-forum-liegerad-schnell": "vm-forum-liegerad-schnell",
+      "vm-forum-velomobil-schnell": "vm-forum-velomobil-schnell"
+    }
+  },
+  "sidebar": {
+    "custom-profile": {
+      "title": "Benutzerdefiniertes Profil"
+    },
+    "data": {
+      "title": "Daten"
+    },
+    "itinerary": {
+      "title": "Reiseroute"
+    },
+    "layers": {
+      "custom-layers": "Benutzerdefinierte Ebenen",
+      "customize": "Benutzerdefinierte Ebenen hinzufügen oder entfernen",
+      "table": {
+        "URL": "URL",
+        "empty": "Noch keine benutzerdefinierte Ebene definiert.",
+        "name": "Name",
+        "type": "Type"
+      },
+      "title": "Ebene"
+    },
+    "profile": {
+      "clear": "Löschen",
+      "help": "Hilfe",
+      "placeholder": "Erstelle benutzerdefiniertes Profil hier.",
+      "upload": "Hochladen"
+    }
+  },
+  "title": "BRouter Web Client",
+  "warning": {
+    "cannot-get-route": "Fehler beim Abrufen der Routen-URL",
+    "no-response": "Keine Antwort vom Server",
+    "no-route-found": "Fehler: kann für angegebene Punkte keine Route finden. Vielleicht die Punkte näher an Straßen verschieben?",
+    "profile-error": "Profil-Fehler: keine oder leere Antwort vom Server",
+    "temporary-profile": "<strong>Note:</strong> Hochgeladene benutzerdefinierte Profile nur verübergehend auf dem Server zwischengespeichert. <br/>Bitte Bearbeitungen auf dem lokalen PC speichern.",
+    "upload-error": "Fehler beim Hochladen: {{error}}"
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,171 @@
+{
+  "about": {
+    "bug-reports": "Bug reports and feature requests:",
+    "bug-reports-back": "server / backend, routing engine, Android app, profiles, brouter.de site:",
+    "bug-reports-front": "web client / frontend:",
+    "contact": "Contact:",
+    "data": "Data:",
+    "data-description": "This is based on <a href=\"https://www.openstreetmap.org\" target=\"_blank\">OpenStreetMap</a>. It is usually updated once a week when a new Planet file is available, see dates of <a href=\"http://brouter.de/brouter/segments4/\" target=\"_blank\">data files</a>.",
+    "description": "Online service of the BRouter routing engine. For the offline Android app and more information see <a href=\"http://brouter.de/\" target=\"_blank\">brouter.de</a>.",
+    "details": "<i><a href=\"http://brouter.de/privacypolicy.html\" target=\"_blank\">Privacy Policy</a></i>, \n<i><a href=\"https://github.com/nrenner/brouter-web#credits-and-licenses\" target=\"_blank\">Credits</a></i>,\n<i><a href=\"https://github.com/nrenner/brouter-web/blob/master/CHANGELOG.md\" target=\"_blank\">Changelog</a></i> and\n<i><a href=\"https://github.com/nrenner/brouter-web#readme\" target=\"_blank\">more info</a></i> on the client.",
+    "support": "General discussions/questions, support:",
+    "title": "About"
+  },
+  "credits": {
+    "brouter": "BRouter",
+    "brouter-license": "<a target=\"_blank\" href=\"http://brouter.de/brouter\">BRouter</a> &copy; Arndt Brenschede",
+    "cycling-hiking-tiles": "Cycling & Hiking tiles",
+    "digitalglobe-license": "&copy; <a href=\"https://www.digitalglobe.com/platforms/mapsapi\">DigitalGlobe</a> (<a href=\"https://bit.ly/mapsapiview\">Terms of Use</a>)",
+    "esri-license": "<a target=\"_blank\" href=\"http://goto.arcgisonline.com/maps/World_Imagery\">World Imagery</a> &copy; <a target=\"_blank\" href=\"https://www.esri.com/\">Esri</a>, sources: Esri, DigitalGlobe, Earthstar Geographics, CNES/Airbus DS, GeoEye, USDA FSA, USGS, Getmapping, Aerogrid, IGN, IGP, and the GIS User Community",
+    "esri-tiles": "Esri World Imagery",
+    "map-data": "Map data",
+    "nominatim": "Search by <a href=\"https://wiki.openstreetmap.org/wiki/Nominatim\" target=\"_blank\" data-i18n=\"credits.nominatim\">Nominatim</a>",
+    "opencyclemap-outdoors-tiles": "OpenCycleMap & Outdoors tiles",
+    "openstreetmap": "&copy; <a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\" >OpenStreetMap contributors</a> under <a target=\"_blank\" href=\"https://opendatacommons.org/licenses/odbl/\" >ODbL</a>",
+    "opentopomap-license": "&copy; <a target=\"_blank\" href=\"https://opentopomap.org\">OpenTopoMap</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a> <a target=\"_blank\" href=\"http://viewfinderpanoramas.org\">SRTM</a>",
+    "opentopomap-tiles": "OpenTopoMap tiles",
+    "osm-license": "<a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\">openstreetmap.org</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "osm-tiles": "OpenStreetMap tiles",
+    "osmde-tiles": "OpenStreetMap.de tiles",
+    "thunderforest-license": "&copy; <a target=\"_blank\" href=\"https://www.thunderforest.com\">Thunderforest</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "waymarked-license": "&copy; <a target=\"_blank\" href=\"https://cycling.waymarkedtrails.org\">Waymarked Trails</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/de/deed.en\">CC-BY-SA 3.0 DE</a>"
+  },
+  "footer": {
+    "ascend": "Ascend (Plain ascend)",
+    "cost": "Cost (Mean cost factor)",
+    "distance": "Distance",
+    "kilometer": "kilometer",
+    "kilometer-abbrev": "km",
+    "kilowatthour": "kilowatt hour",
+    "kilowatthour-abbrev": "kWh",
+    "meter": "meter",
+    "meter-abbrev": "m",
+    "minutes": "minutes",
+    "minutes-abbrev": "min",
+    "total-energy": "Total Energy (per 100km)",
+    "travel-time": "Travel time"
+  },
+  "layers": {
+    "add-base": "Add base layer",
+    "add-overlay": "Add overlay",
+    "customize": "Customize layers",
+    "placeholder-layer-name": "Custom layer name. (ex: OpenStreetMap)",
+    "placeholder-layer-url": "Custom layer URL. (ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)",
+    "remove-selection": "Remove selection"
+  },
+  "map": {
+    "attribution-osm-long": "OpenStreetMap contributors",
+    "attribution-osm-short": "OpenStreetMap",
+    "clear-route": "Clear route",
+    "copyright": "Copyright",
+    "cycling": "Cycling",
+    "delete-nogo-areas": "&nbsp;&nbsp;also delete all no-go areas",
+    "delete-route": "Delete route?",
+    "draw-route-start": "Draw route (D key)",
+    "draw-route-stop": "Stop drawing route (ESC key)",
+    "hiking": "Hiking",
+    "layer": {
+      "bing": "Bing Aerial",
+      "cycle": "OpenCycleMap (Thunderf.)",
+      "cycling": "Cycling (Waymarked Trails)",
+      "digitalglobe": "DigitalGlobe Recent Imagery",
+      "esri": "Esri World Imagery",
+      "hiking": "Hiking (Waymarked Trails)",
+      "osm": "OpenStreetMap",
+      "osmde": "OpenStreetMap.de",
+      "outdoors": "Outdoors (Thunderforest)",
+      "strava-segments": "Strava segments",
+      "topo": "OpenTopoMap"
+    },
+    "loading": "Loading…",
+    "locate-me": "Show me where I am",
+    "nogo": {
+      "cancel": "Cancel drawing no-go area",
+      "click-drag": "Click and drag to draw circle",
+      "draw": "Draw no-go area (circle)",
+      "edit": "Click to edit",
+      "help": "&square; = move / resize, <span class=\"fa fa-trash-o\"></span> = delete,<br>click circle to quit editing"
+    },
+    "opacity-slider": "Set transparency of route track and markers",
+    "privacy": "Privacy",
+    "strava-biking": "Show Strava biking segments",
+    "strava-running": "Show Strava running segments",
+    "zoomInTitle": "Zoom in",
+    "zoomOutTitle": "Zoom out"
+  },
+  "navbar": {
+    "about": "About",
+    "alternative": {
+      "first": "1st alternative",
+      "original": "Original",
+      "second": "2nd alternative",
+      "third": "3rd alternative"
+    },
+    "download": {
+      "csv": "data CSV",
+      "geojson": "GeoJSON",
+      "gpx": "GPX",
+      "kml": "KML",
+      "title": "Download"
+    },
+    "profile": {
+      "car-eco": "Car (economic)",
+      "car-fast": "Car (fast)",
+      "car-test": "Car (test)",
+      "custom": "Custom",
+      "fastbike": "Fastbike",
+      "fastbike-asia-pacific": "Fastbike (Asia Pacific)",
+      "fastbike-lowtraffic": "Fastbike low traffic",
+      "hiking-beta": "Hiking (beta)",
+      "moped": "Moped",
+      "rail": "Rail",
+      "river": "River",
+      "safety": "Safety",
+      "shortest": "Shortest",
+      "trekking": "Trekking",
+      "trekking-ignore-cr": "Trekking (ignore cylce routes)",
+      "trekking-noferries": "Trekking (no ferries)",
+      "trekking-nosteps": "Trekking (no steps)",
+      "trekking-steep": "Trekking steep",
+      "vm-forum-liegerad-schnell": "vm-forum-liegerad-schnell",
+      "vm-forum-velomobil-schnell": "vm-forum-velomobil-schnell"
+    }
+  },
+  "sidebar": {
+    "custom-profile": {
+      "title": "Custom profile"
+    },
+    "data": {
+      "title": "Data"
+    },
+    "itinerary": {
+      "title": "Itinerary"
+    },
+    "layers": {
+      "custom-layers": "Custom layers",
+      "customize": "Add or remove custom layers",
+      "table": {
+        "URL": "URL",
+        "empty": "No custom layer configured yet.",
+        "name": "Name",
+        "type": "Type"
+      },
+      "title": "Layers"
+    },
+    "profile": {
+      "clear": "Clear",
+      "help": "Help",
+      "placeholder": "Write your custom profile here.",
+      "upload": "Upload"
+    }
+  },
+  "title": "BRouter web client",
+  "warning": {
+    "cannot-get-route": "Error getting route URL",
+    "no-response": "no response from server",
+    "no-route-found": "Error: cannot find a route for given points. Maybe try to move them closer to roads?",
+    "profile-error": "Profile error: no or empty response from server",
+    "temporary-profile": "<strong>Note:</strong> Uploaded custom profiles are only cached temporarily on the server.<br/>Please save your edits to your local PC.",
+    "upload-error": "Upload error: {{error}}"
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,171 @@
+{
+  "about": {
+    "bug-reports": "Reporter un problème ou une amélioration :",
+    "bug-reports-back": "serveur, moteur de routage, app Android, profiles, site brouter.de :",
+    "bug-reports-front": "client web :",
+    "contact": "Contact :",
+    "data": "Données :",
+    "data-description": "Les données reposent sur <a href=\"https://www.openstreetmap.org\" target=\"_blank\">OpenStreetMap</a>. La mise à jour est généralement hebdomadaire, voir <a href=\"http://brouter.de/brouter/segments4/\" target=\"_blank\">les fichiers de données</a>. ",
+    "description": "Service web pour le moteur de routage BRouter. Pour l'app Android et de plus amples informations, voir <a href=\"http://brouter.de/\" target=\"_blank\">brouter.de</a>.",
+    "details": "<i><a href=\"http://brouter.de/privacypolicy.html\" target=\"_blank\">Respect de la vie privée</a></i>, \n<i><a href=\"https://github.com/nrenner/brouter-web#credits-and-licenses\" target=\"_blank\">Crédits</a></i>,\n<i><a href=\"https://github.com/nrenner/brouter-web/blob/master/CHANGELOG.md\" target=\"_blank\">Changements</a></i> et\n<i><a href=\"https://github.com/nrenner/brouter-web#readme\" target=\"_blank\">plus d'infos</a></i> sur le client web.",
+    "support": "Discussions/Questions générales, support :",
+    "title": "À propos"
+  },
+  "credits": {
+    "brouter": "BRouter",
+    "brouter-license": "<a target=\"_blank\" href=\"http://brouter.de/brouter\">BRouter</a> &copy; Arndt Brenschede",
+    "cycling-hiking-tiles": "Tuiles pour Vélo & Piéton",
+    "digitalglobe-license": "&copy; <a href=\"https://www.digitalglobe.com/platforms/mapsapi\">DigitalGlobe</a> (<a href=\"https://bit.ly/mapsapiview\">Conditions d'utilisation</a>)",
+    "esri-license": "<a target=\"_blank\" href=\"http://goto.arcgisonline.com/maps/World_Imagery\">World Imagery</a> &copy; <a target=\"_blank\" href=\"https://www.esri.com/\">Esri</a>, sources : Esri, DigitalGlobe, Earthstar Geographics, CNES/Airbus DS, GeoEye, USDA FSA, USGS, Getmapping, Aerogrid, IGN, IGP, et la communauté d'utilisateurs GIS",
+    "esri-tiles": "Imagerie mondiale Esri",
+    "map-data": "Données de carte",
+    "nominatim": "Recherche par <a href=\"https://wiki.openstreetmap.org/wiki/Nominatim\" target=\"_blank\" data-i18n=\"credits.nominatim\">Nominatim</a>",
+    "opencyclemap-outdoors-tiles": "Tuiles OpenCycleMap & Outdoors",
+    "openstreetmap": "&copy; <a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\" >contributeurs OpenStreetMap</a> sous <a target=\"_blank\" href=\"https://opendatacommons.org/licenses/odbl/\" >ODbL</a>",
+    "opentopomap-license": "&copy; <a target=\"_blank\" href=\"https://opentopomap.org\">OpenTopoMap</a> sous <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a> <a target=\"_blank\" href=\"http://viewfinderpanoramas.org\">SRTM</a>",
+    "opentopomap-tiles": "Tuiles OpenTopoMap",
+    "osm-license": "<a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\">openstreetmap.org</a> sous <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "osm-tiles": "Tuiles OpenStreetMap",
+    "osmde-tiles": "Tuiles OpenStreetMap.de",
+    "thunderforest-license": "&copy; <a target=\"_blank\" href=\"https://www.thunderforest.com\">Thunderforest</a> sous <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "waymarked-license": "&copy; <a target=\"_blank\" href=\"https://cycling.waymarkedtrails.org\">Waymarked Trails</a> sous <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/de/deed.en\">CC-BY-SA 3.0 DE</a>"
+  },
+  "footer": {
+    "ascend": "Montée (pleine ascension)",
+    "cost": "Coût (facteur coût moyen)",
+    "distance": "Distance",
+    "kilometer": "kilomètre",
+    "kilometer-abbrev": "km",
+    "kilowatthour": "kilowattheure",
+    "kilowatthour-abbrev": "kWh",
+    "meter": "mètre",
+    "meter-abbrev": "m",
+    "minutes": "minutes",
+    "minutes-abbrev": "min",
+    "total-energy": "Énergie totale (pour 100km)",
+    "travel-time": "Temps de trajet"
+  },
+  "layers": {
+    "add-base": "Ajouter un fond de carte ",
+    "add-overlay": "Ajouter un calque superposable",
+    "customize": "Personnaliser les calques",
+    "placeholder-layer-name": "Nom du calque (ex : OpenStreetMap).",
+    "placeholder-layer-url": "URL du calque (ex : https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png).",
+    "remove-selection": "Supprimer la sélection"
+  },
+  "map": {
+    "attribution-osm-long": "Contributeurs OpenStreetMap",
+    "attribution-osm-short": "OpenStreetMap",
+    "clear-route": "Supprimer l'itinéraire",
+    "copyright": "Copyright",
+    "cycling": "Vélo",
+    "delete-nogo-areas": "&nbsp;&nbsp;supprimer aussi toutes les zones interdites",
+    "delete-route": "Supprimer l'itinéraire ?",
+    "draw-route-start": "Dessiner l'itinéraire (touche D)",
+    "draw-route-stop": "Arrêter de dessiner l'itinéraire (touche ECH)",
+    "hiking": "Randonnée",
+    "layer": {
+      "bing": "Aérienne BING",
+      "cycle": "OpenCycleMap (Thunderf.)",
+      "cycling": "Cycling (Sentiers balisés)",
+      "digitalglobe": "Imagerie récente DigitalGlobe",
+      "esri": "Imagerie mondiale Esri",
+      "hiking": "Randonnée (Sentiers balisés)",
+      "osm": "OpenStreetMap",
+      "osmde": "OpenStreetMap.de",
+      "outdoors": "Plein air (Thunderforest)",
+      "strava-segments": "Segments Strava",
+      "topo": "OpenTopoMap"
+    },
+    "loading": "Chargement…",
+    "locate-me": "Où suis-je ?",
+    "nogo": {
+      "cancel": "Annuler la zone interdite",
+      "click-drag": "Cliquer et faire glisser pour dessiner un cercle",
+      "draw": "Dessiner une zone interdite (cercle)",
+      "edit": "Cliquer pour éditer",
+      "help": "&square; = déplacer / redimensionner, <span class=\"fa fa-trash-o\"></span> = supprimer,<br>cliquer sur le cercle pour arrêter l'édition"
+    },
+    "opacity-slider": "Définie l'opacity de l'itinéraire et des marqueurs",
+    "privacy": "Vie privée",
+    "strava-biking": "Afficher les segments Strava vélo",
+    "strava-running": "Afficher les segments Strava à pied",
+    "zoomInTitle": "Zoomer",
+    "zoomOutTitle": "Dézoomer"
+  },
+  "navbar": {
+    "about": "À propos",
+    "alternative": {
+      "first": "1ère alternative",
+      "original": "Originale",
+      "second": "2nde alternative",
+      "third": "3ème alternative"
+    },
+    "download": {
+      "csv": "CSV",
+      "geojson": "GeoJSON",
+      "gpx": "GPX",
+      "kml": "KML",
+      "title": "Télécharger"
+    },
+    "profile": {
+      "car-eco": "Voiture (économique)",
+      "car-fast": "Voiture (rapide)",
+      "car-test": "Voiture (test)",
+      "custom": "Personnalisé",
+      "fastbike": "Vélo de route",
+      "fastbike-asia-pacific": "Vélo de route (Asie Pacifique)",
+      "fastbike-lowtraffic": "Vélo de route (faible traffic)",
+      "hiking-beta": "Randonnée (beta)",
+      "moped": "Mobylette",
+      "rail": "Train",
+      "river": "Fluvial",
+      "safety": "Sécurité",
+      "shortest": "Le plus court",
+      "trekking": "Cyclotourisme",
+      "trekking-ignore-cr": "Cycloutourisme (ignore pistes cyclables)",
+      "trekking-noferries": "Cyclotourisme (pas de ferries)",
+      "trekking-nosteps": "Cyclotourisme (pas d'escaliers)",
+      "trekking-steep": "Cyclotourisme escarpé",
+      "vm-forum-liegerad-schnell": "vm-forum-liegerad-schnell",
+      "vm-forum-velomobil-schnell": "vm-forum-velomobil-schnell"
+    }
+  },
+  "sidebar": {
+    "custom-profile": {
+      "title": "Profile personnalisé"
+    },
+    "data": {
+      "title": "Données"
+    },
+    "itinerary": {
+      "title": "Itinéraire"
+    },
+    "layers": {
+      "custom-layers": "Calques personels",
+      "customize": "Ajouter ou supprimer des calques",
+      "table": {
+        "URL": "URL",
+        "empty": "Aucun calque personnel trouvé.",
+        "name": "Nom",
+        "type": "Type"
+      },
+      "title": "Calques"
+    },
+    "profile": {
+      "clear": "Nettoyer",
+      "help": "Aide",
+      "placeholder": "Écrivez votre profile personnalisé ici.",
+      "upload": "Envoyer"
+    }
+  },
+  "title": "Client web BRouter",
+  "warning": {
+    "cannot-get-route": "Erreur lors de la réception de l'itinéraire",
+    "no-response": "aucune réponse du serveur",
+    "no-route-found": "Erreur : impossible de trouver un itinéraire correspond. Essayez peut-être de rapprocher les points des routes ?",
+    "profile-error": "Erreur de profile : pas de réponse ou réponse invalide du serveur",
+    "temporary-profile": "<strong>Note :</strong> Les profiles personnalisés téléversés ne sont disponibles que temporairement sur le serveur.<br/>Merci de sauvegarder vorte profile sur votre ordinateur.",
+    "upload-error": "Erreur de téléversement : {{error}}"
+  }
+}

--- a/locales/keys.js
+++ b/locales/keys.js
@@ -1,0 +1,21 @@
+// this file contains translatable keys that are dynamic / not visible by i18n extractor tool
+i18next.t('navbar.profile.car-eco');
+i18next.t('navbar.profile.car-fast');
+i18next.t('navbar.profile.car-test');
+i18next.t('navbar.profile.fastbike');
+i18next.t('navbar.profile.fastbike-asia-pacific');
+i18next.t('navbar.profile.fastbike-asia-pacific');
+i18next.t('navbar.profile.fastbike-lowtraffic');
+i18next.t('navbar.profile.hiking-beta');
+i18next.t('navbar.profile.moped');
+i18next.t('navbar.profile.rail');
+i18next.t('navbar.profile.river');
+i18next.t('navbar.profile.safety');
+i18next.t('navbar.profile.shortest');
+i18next.t('navbar.profile.trekking');
+i18next.t('navbar.profile.trekking-ignore-cr');
+i18next.t('navbar.profile.trekking-noferries');
+i18next.t('navbar.profile.trekking-nosteps');
+i18next.t('navbar.profile.trekking-steep');
+i18next.t('navbar.profile.vm-forum-liegerad-schnell');
+i18next.t('navbar.profile.vm-forum-velomobil-schnell');

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -1,0 +1,171 @@
+{
+  "about": {
+    "bug-reports": "錯誤報告和功能需求：",
+    "bug-reports-back": "server / backend, routing engine, Android app, profiles, brouter.de site:",
+    "bug-reports-front": "web client / frontend:",
+    "contact": "聯絡：",
+    "data": "日期：",
+    "data-description": "This is based on <a href=\"https://www.openstreetmap.org\" target=\"_blank\">OpenStreetMap</a>. It is usually updated once a week when a new Planet file is available, see dates of <a href=\"http://brouter.de/brouter/segments4/\" target=\"_blank\">data files</a>.",
+    "description": "Online service of the BRouter routing engine. For the offline Android app and more information see <a href=\"http://brouter.de/\" target=\"_blank\">brouter.de</a>.",
+    "details": "<i><a href=\"http://brouter.de/privacypolicy.html\" target=\"_blank\">Privacy Policy</a></i>, \n<i><a href=\"https://github.com/nrenner/brouter-web#credits-and-licenses\" target=\"_blank\">Credits</a></i>,\n<i><a href=\"https://github.com/nrenner/brouter-web/blob/master/CHANGELOG.md\" target=\"_blank\">Changelog</a></i> and\n<i><a href=\"https://github.com/nrenner/brouter-web#readme\" target=\"_blank\">more info</a></i> on the client.",
+    "support": "General discussions/questions, support:",
+    "title": "關於"
+  },
+  "credits": {
+    "brouter": "BRouter",
+    "brouter-license": "<a target=\"_blank\" href=\"http://brouter.de/brouter\">BRouter</a> &copy; Arndt Brenschede",
+    "cycling-hiking-tiles": "Cycling & Hiking tiles",
+    "digitalglobe-license": "&copy; <a href=\"https://www.digitalglobe.com/platforms/mapsapi\">DigitalGlobe</a> (<a href=\"https://bit.ly/mapsapiview\">Terms of Use</a>)",
+    "esri-license": "<a target=\"_blank\" href=\"http://goto.arcgisonline.com/maps/World_Imagery\">World Imagery</a> &copy; <a target=\"_blank\" href=\"https://www.esri.com/\">Esri</a>, sources: Esri, DigitalGlobe, Earthstar Geographics, CNES/Airbus DS, GeoEye, USDA FSA, USGS, Getmapping, Aerogrid, IGN, IGP, and the GIS User Community",
+    "esri-tiles": "Esri World Imagery",
+    "map-data": "地圖資料",
+    "nominatim": "Search by <a href=\"https://wiki.openstreetmap.org/wiki/Nominatim\" target=\"_blank\" data-i18n=\"credits.nominatim\">Nominatim</a>",
+    "opencyclemap-outdoors-tiles": "OpenCycleMap & Outdoors tiles",
+    "openstreetmap": "&copy; <a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\" >OpenStreetMap contributors</a> under <a target=\"_blank\" href=\"https://opendatacommons.org/licenses/odbl/\" >ODbL</a>",
+    "opentopomap-license": "&copy; <a target=\"_blank\" href=\"https://opentopomap.org\">OpenTopoMap</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a> <a target=\"_blank\" href=\"http://viewfinderpanoramas.org\">SRTM</a>",
+    "opentopomap-tiles": "OpenTopoMap tiles",
+    "osm-license": "<a target=\"_blank\" href=\"https://www.openstreetmap.org/copyright\">openstreetmap.org</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "osm-tiles": "OpenStreetMap 圖磚",
+    "osmde-tiles": "OpenStreetMap.de 圖磚",
+    "thunderforest-license": "&copy; <a target=\"_blank\" href=\"https://www.thunderforest.com\">Thunderforest</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA 2.0</a>",
+    "waymarked-license": "&copy; <a target=\"_blank\" href=\"https://cycling.waymarkedtrails.org\">Waymarked Trails</a> under <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/de/deed.en\">CC-BY-SA 3.0 DE</a>"
+  },
+  "footer": {
+    "ascend": "Ascend (Plain ascend)",
+    "cost": "Cost (Mean cost factor)",
+    "distance": "Distance",
+    "kilometer": "kilometer",
+    "kilometer-abbrev": "km",
+    "kilowatthour": "kilowatt hour",
+    "kilowatthour-abbrev": "kWh",
+    "meter": "meter",
+    "meter-abbrev": "m",
+    "minutes": "minutes",
+    "minutes-abbrev": "min",
+    "total-energy": "Total Energy (per 100km)",
+    "travel-time": "Travel time"
+  },
+  "layers": {
+    "add-base": "Add base layer",
+    "add-overlay": "Add overlay",
+    "customize": "Customize layers",
+    "placeholder-layer-name": "Custom layer name. (ex: OpenStreetMap)",
+    "placeholder-layer-url": "Custom layer URL. (ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)",
+    "remove-selection": "Remove selection"
+  },
+  "map": {
+    "attribution-osm-long": "OpenStreetMap contributors",
+    "attribution-osm-short": "OpenStreetMap",
+    "clear-route": "Clear route",
+    "copyright": "Copyright",
+    "cycling": "Cycling",
+    "delete-nogo-areas": "&nbsp;&nbsp;also delete all no-go areas",
+    "delete-route": "Delete route?",
+    "draw-route-start": "Draw route (D key)",
+    "draw-route-stop": "Stop drawing route (ESC key)",
+    "hiking": "Hiking",
+    "layer": {
+      "bing": "Bing Aerial",
+      "cycle": "OpenCycleMap (Thunderf.)",
+      "cycling": "Cycling (Waymarked Trails)",
+      "digitalglobe": "DigitalGlobe Recent Imagery",
+      "esri": "Esri World Imagery",
+      "hiking": "Hiking (Waymarked Trails)",
+      "osm": "OpenStreetMap",
+      "osmde": "OpenStreetMap.de",
+      "outdoors": "Outdoors (Thunderforest)",
+      "strava-segments": "Strava segments",
+      "topo": "OpenTopoMap"
+    },
+    "loading": "Loading…",
+    "locate-me": "Show me where I am",
+    "nogo": {
+      "cancel": "Cancel drawing no-go area",
+      "click-drag": "Click and drag to draw circle",
+      "draw": "Draw no-go area (circle)",
+      "edit": "Click to edit",
+      "help": "&square; = move / resize, <span class=\"fa fa-trash-o\"></span> = delete,<br>click circle to quit editing"
+    },
+    "opacity-slider": "Set transparency of route track and markers",
+    "privacy": "Privacy",
+    "strava-biking": "Show Strava biking segments",
+    "strava-running": "Show Strava running segments",
+    "zoomInTitle": "Zoom in",
+    "zoomOutTitle": "Zoom out"
+  },
+  "navbar": {
+    "about": "About",
+    "alternative": {
+      "first": "1st alternative",
+      "original": "Original",
+      "second": "2nd alternative",
+      "third": "3rd alternative"
+    },
+    "download": {
+      "csv": "data CSV",
+      "geojson": "GeoJSON",
+      "gpx": "GPX",
+      "kml": "KML",
+      "title": "Download"
+    },
+    "profile": {
+      "car-eco": "Car (economic)",
+      "car-fast": "Car (fast)",
+      "car-test": "Car (test)",
+      "custom": "Custom",
+      "fastbike": "Fastbike",
+      "fastbike-asia-pacific": "Fastbike (Asia Pacific)",
+      "fastbike-lowtraffic": "Fastbike low traffic",
+      "hiking-beta": "Hiking (beta)",
+      "moped": "Moped",
+      "rail": "Rail",
+      "river": "River",
+      "safety": "Safety",
+      "shortest": "Shortest",
+      "trekking": "Trekking",
+      "trekking-ignore-cr": "Trekking (ignore cylce routes)",
+      "trekking-noferries": "Trekking (no ferries)",
+      "trekking-nosteps": "Trekking (no steps)",
+      "trekking-steep": "Trekking steep",
+      "vm-forum-liegerad-schnell": "vm-forum-liegerad-schnell",
+      "vm-forum-velomobil-schnell": "vm-forum-velomobil-schnell"
+    }
+  },
+  "sidebar": {
+    "custom-profile": {
+      "title": "Custom profile"
+    },
+    "data": {
+      "title": "Data"
+    },
+    "itinerary": {
+      "title": "Itinerary"
+    },
+    "layers": {
+      "custom-layers": "Custom layers",
+      "customize": "Add or remove custom layers",
+      "table": {
+        "URL": "URL",
+        "empty": "No custom layer configured yet.",
+        "name": "Name",
+        "type": "Type"
+      },
+      "title": "Layers"
+    },
+    "profile": {
+      "clear": "Clear",
+      "help": "Help",
+      "placeholder": "Write your custom profile here.",
+      "upload": "Upload"
+    }
+  },
+  "title": "BRouter web client",
+  "warning": {
+    "cannot-get-route": "Error getting route URL",
+    "no-response": "no response from server",
+    "no-route-found": "Error: cannot find a route for given points. Maybe try to move them closer to roads?",
+    "profile-error": "Profile error: no or empty response from server",
+    "temporary-profile": "<strong>Note:</strong> Uploaded custom profiles are only cached temporarily on the server.<br/>Please save your edits to your local PC.",
+    "upload-error": "Upload error: {{error}}"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "js/index.js",
   "scripts": {
     "build": "gulp",
+    "transifex-push": "gulp i18next && tx push --source",
+    "transifex-pull": "tx pull --all --minimum-perc 1",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -23,7 +25,11 @@
     "d3": "~3.5.5",
     "datatables": "~1.10.16",
     "font-awesome": "^4.7.0",
+    "i18next": "^15.0.4",
+    "i18next-browser-languagedetector": "^3.0.1",
+    "i18next-xhr-backend": "^2.0.1",
     "jquery": "3.3.1",
+    "jquery-i18next": "^1.2.1",
     "leaflet": "~1.3.0",
     "leaflet-control-geocoder": "~1.5.8",
     "leaflet-easybutton": "*",
@@ -32,9 +38,10 @@
     "leaflet-plugins": "~3.0.0",
     "leaflet-routing": "nrenner/leaflet-routing#dev",
     "leaflet-sidebar-v2": "nrenner/leaflet-sidebar-v2#dev",
+    "leaflet-triangle-marker": "^1.0.1",
     "leaflet.locatecontrol": "^0.60.0",
     "leaflet.restoreview": "makinacorpus/Leaflet.RestoreView#master",
-    "leaflet.stravasegments": "*",
+    "leaflet.stravasegments": "^2.0.3",
     "mapbbcode": "MapBBCode/mapbbcode#v1.2.0",
     "seiyria-bootstrap-slider": "seiyria/bootstrap-slider#^9.8.1",
     "tether": "1.4.5",
@@ -63,6 +70,7 @@
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.7",
     "gulp-zip": "^4.0.0",
+    "i18next-scanner": "^2.9.1",
     "npmfiles": "^0.1.1"
   },
   "overrides": {
@@ -92,13 +100,13 @@
         "js/leaflet-sidebar.js",
         "css/leaflet-sidebar.css"
       ]
-    },    
+    },
     "leaflet-easybutton": {
       "main": [
         "src/easy-button.js",
         "src/easy-button.css"
       ]
-    },    
+    },
     "bootstrap-select": {
       "main": [
         "js/bootstrap-select.js",
@@ -129,12 +137,6 @@
       ],
       "dependencies": null
     },
-    "leaflet.stravasegments": {
-      "main": [
-        "dist/leaflet-triangle-marker.js",
-        "dist/L.StravaSegments.js"
-      ]
-    },
     "leaflet-control-geocoder": {
       "main": [
         "dist/Control.Geocoder.js",
@@ -148,6 +150,9 @@
     "Leaflet.RestoreView": {
       "main": "leaflet.restoreview.js"
     },
+    "leaflet.stravasegments": {
+      "main": "index.js"
+    },
     "font-awesome": {
       "main": [
         "css/font-awesome.css",
@@ -160,11 +165,8 @@
         "dist/L.Control.Locate.css"
       ]
     },
-    "autosize": {
-      "main": "dist/autosize.js"
-    },
     "seiyria-bootstrap-slider": {
-      "main": [ 
+      "main": [
         "dist/bootstrap-slider.js",
         "dist/css/bootstrap-slider.css"
       ],
@@ -175,6 +177,26 @@
     },
     "mapbbcode": {
       "main": "src/controls/PermalinkAttribution.js"
+    },
+    "i18next": {
+      "main": [
+        "dist/umd/i18next.js"
+      ]
+    },
+    "i18next-xhr-backend": {
+      "main": [
+        "dist/umd/i18nextXHRBackend.js"
+      ]
+    },
+    "i18next-browser-languagedetector": {
+      "main": [
+        "dist/umd/i18nextBrowserLanguageDetector.js"
+      ]
+    },
+    "jquery-i18next": {
+      "main": [
+        "dist/umd/jquery-i18next.js"
+      ]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@gulp-sourcemaps/map-sources@1.X":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz#890ae7c5d8c877f6d384860215ace9d7ec945bda"
@@ -20,10 +27,73 @@
   resolved "https://registry.yarnpkg.com/@mapbox/polyline/-/polyline-1.0.0.tgz#b6f1c3cf61f8dddcf9ac6dce0b2e50e5f4e965bc"
   integrity sha512-5Vu99e/+kVF0h0eiWa3er3bYnjorq6SGTn06HqeinFAETlQpcHGj7+DanmFlNyXkgvRcKi0nQytuMm6QA2CkAQ==
 
+acorn-bigint@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-bigint/-/acorn-bigint-0.3.1.tgz#edb40a414dcaf5a09c2933db6bed79454b3ff46a"
+  integrity sha512-WT9LheDC4/d/sD/jgC6L5UMq4U9X3KNMy0JrXp/MdJL83ZqcuPQuMkj50beOX0dMub8IoZUYycfN7bIVZuU5zg==
+
+acorn-class-fields@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-0.2.1.tgz#748058bceeb0ef25164bbc671993984083f5a085"
+  integrity sha512-US/kqTe0H8M4LN9izoL+eykVAitE68YMuYZ3sHn3i1fjniqR7oQ3SPvuMK/VT1kjOQHrx5Q88b90TtOKgAv2hQ==
+
+acorn-dynamic-import@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
+  integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
+
+acorn-export-ns-from@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-export-ns-from/-/acorn-export-ns-from-0.1.0.tgz#192687869bba3bcb2ef1a1ba196486ea7e100e5c"
+  integrity sha512-QDQJBe2DfxNBIMxs+19XY2i/XXilJn+kPgX30HWNYK4IXoNj3ACNSWPU7szL0SzqjFyOG4zoZxG9P7JfNw5g7A==
+
+acorn-import-meta@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-meta/-/acorn-import-meta-1.0.0.tgz#6cff1f01db3b60148934823d3d2dd0c08354aead"
+  integrity sha512-yX652u86bKzuM+mzEHV84T0R+srQwTOmprUiFC3zlhlc02lBQzqxkB/H/7jexX9vlz/TRuQiZs9mKEDK3bbmhw==
+
+acorn-jsx@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+
+acorn-private-methods@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-0.2.3.tgz#d951cc16224993d79426a124ca2be39e72c5a38c"
+  integrity sha512-61BtfmwjB/jQCSCnomKV+IFpVSFviN9wV4P1qWmkz8dZvG97Cf6VwGx6nTvFjw2yqyyA+HlqVueu9cq+n3spJw==
+
+acorn-stage3@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-stage3/-/acorn-stage3-1.0.0.tgz#0b3e288d697c43512aee3549b39aa0672e409384"
+  integrity sha512-7PiPkjroE9sdxMmGDSfyriB8YputoGAyhvM40f/3VRr8Dvb25DJxOtnqvEsKhAvqaKulwKTaueupGJB+8UCpnQ==
+  dependencies:
+    acorn-bigint "^0.3.1"
+    acorn-class-fields "^0.2.0"
+    acorn-dynamic-import "^4.0.0"
+    acorn-export-ns-from "^0.1.0"
+    acorn-import-meta "^1.0.0"
+    acorn-private-methods "^0.2.0"
+    acorn-static-class-features "^0.1.0"
+
+acorn-static-class-features@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-static-class-features/-/acorn-static-class-features-0.1.1.tgz#dc621b0b33b904f750e2f9293aa27535e4a25d38"
+  integrity sha512-oBHlqP72RdoZNcIr/f1RpwdYRpS0mnYv8lVWS9V7CiXAOkRCJH9CLT9WGGQQ6Jtr0HG5eMyOmT8KLZaqvY2jkg==
+
+acorn-walk@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
+  integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
+
 acorn@4.X:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
   integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
+
+acorn@^6.0.4:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
+  integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
 
 ajv@^6.5.5:
   version "6.9.1"
@@ -103,6 +173,13 @@ any-shell-escape@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/any-shell-escape/-/any-shell-escape-0.1.1.tgz#d55ab972244c71a9a5e1ab0879f30bf110806959"
   integrity sha1-1Vq5ciRMcaml4asIefML8RCAaVk=
+
+append-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/append-buffer/-/append-buffer-1.0.2.tgz#d8220cf466081525efea50614f3de6514dfa58f1"
+  integrity sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=
+  dependencies:
+    buffer-equal "^1.0.0"
 
 archy@^1.0.0:
   version "1.0.0"
@@ -348,6 +425,11 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
+buffer-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
+  integrity sha1-WWFrSYME1Var1GaWayLu2j7KX74=
+
 bump-regex@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/bump-regex/-/bump-regex-2.9.0.tgz#b1770cfa62d532f523661246877c16bd0dbbd038"
@@ -470,6 +552,15 @@ clone-buffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
   integrity sha1-4+JbIHrE5wGvch4staFnksrD3Fg=
 
+clone-deep@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -541,6 +632,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.15.1:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -558,7 +654,7 @@ concat-with-sourcemaps@^1.0.0:
   dependencies:
     source-map "^0.6.1"
 
-convert-source-map@1.X:
+convert-source-map@1.X, convert-source-map@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
@@ -673,12 +769,24 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 defaults@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -746,7 +854,7 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-duplexify@^3.5.0:
+duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
   integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
@@ -772,6 +880,14 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+editions@^2.1.2, editions@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-2.1.3.tgz#727ccf3ec2c7b12dcc652c71000f16c4824d6f7d"
+  integrity sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==
+  dependencies:
+    errlop "^1.1.1"
+    semver "^5.6.0"
+
 editor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
@@ -782,7 +898,7 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
   integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
 
-end-of-stream@^1.0.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
@@ -795,6 +911,23 @@ end-of-stream@~0.1.5:
   integrity sha1-jhdyBsPICDfYVjLouTWd/osvbq8=
   dependencies:
     once "~1.3.0"
+
+ensure-array@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ensure-array/-/ensure-array-1.0.0.tgz#317e9fc632c656bb849eb649133528e205b23abc"
+  integrity sha512-A+3Ntl5WS+GjDnHtC67dKIjw+IoGoeFdNvjn3ZfKEmZgWUz0nxBPE4W52QMCbGZsat0VwWskD5T6AEpe3T2d1g==
+
+eol@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
+  integrity sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==
+
+errlop@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/errlop/-/errlop-1.1.1.tgz#d9ae4c76c3e64956c5d79e6e035d6343bfd62250"
+  integrity sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==
+  dependencies:
+    editions "^2.1.2"
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -986,6 +1119,14 @@ flagged-respawn@^1.0.0:
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
   integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
 
+flush-write-stream@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
+  integrity sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.3.6"
+
 font-awesome@4, font-awesome@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
@@ -1034,10 +1175,23 @@ from@^0.1.7:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
+fs-mkdirp-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
+  integrity sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=
+  dependencies:
+    graceful-fs "^4.1.11"
+    through2 "^2.0.3"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 gaze@^0.5.1:
   version "0.5.2"
@@ -1086,6 +1240,14 @@ github-url-to-object@^1.4.2:
   dependencies:
     is-url "^1.1.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob-stream@^3.1.5:
   version "3.1.18"
   resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-3.1.18.tgz#9170a5f12b790306fdfe598f313f8f7954fd143b"
@@ -1097,6 +1259,22 @@ glob-stream@^3.1.5:
     ordered-read-streams "^0.1.0"
     through2 "^0.6.1"
     unique-stream "^1.0.0"
+
+glob-stream@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-6.1.0.tgz#7045c99413b3eb94888d83ab46d0b404cc7bdde4"
+  integrity sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=
+  dependencies:
+    extend "^3.0.0"
+    glob "^7.1.1"
+    glob-parent "^3.1.0"
+    is-negated-glob "^1.0.0"
+    ordered-read-streams "^1.0.0"
+    pumpify "^1.3.5"
+    readable-stream "^2.1.5"
+    remove-trailing-separator "^1.0.1"
+    to-absolute-glob "^2.0.0"
+    unique-stream "^2.0.2"
 
 glob-watcher@^0.0.6:
   version "0.0.6"
@@ -1200,7 +1378,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-graceful-fs@4.X, graceful-fs@^4.1.2:
+graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -1371,6 +1549,13 @@ gulp-replace@^0.5.4:
     readable-stream "^2.0.1"
     replacestream "^4.0.0"
 
+gulp-sort@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-sort/-/gulp-sort-2.0.0.tgz#c6762a2f1f0de0a3fc595a21599d3fac8dba1aca"
+  integrity sha1-xnYqLx8N4KP8WVohWZ0/rI26Gso=
+  dependencies:
+    through2 "^2.0.1"
+
 gulp-sourcemaps@^1.5.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-1.12.1.tgz#b437d1f3d980cf26e81184823718ce15ae6597b6"
@@ -1495,6 +1680,11 @@ has-gulplog@^0.1.0:
   dependencies:
     sparkles "^1.0.0"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -1554,6 +1744,53 @@ hyperquest@~1.2.0:
   dependencies:
     duplexer2 "~0.0.2"
     through2 "~0.6.3"
+
+i18next-browser-languagedetector@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-3.0.1.tgz#a47c43176e8412c91e808afb7c6eb5367649aa8e"
+  integrity sha512-WFjPLNPWl62uu07AHY2g+KsC9qz0tyMq+OZEB/H7N58YKL/JLiCz9U709gaR20Mule/Ppn+uyfVx5REJJjn1HA==
+
+i18next-scanner@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/i18next-scanner/-/i18next-scanner-2.9.1.tgz#4584694e4da50e59a65589813eb98eddef3afc57"
+  integrity sha512-zGbIuMGH7gRQ8CiZCTmLXeol5KC4Xvz68rmWNwp9SVgJdXBMTWOKhGJaf4JAge2/nUeUEK2pOvJQs9Ec5xRKUg==
+  dependencies:
+    acorn "^6.0.4"
+    acorn-jsx "^5.0.1"
+    acorn-stage3 "^1.0.0"
+    acorn-walk "^6.1.1"
+    chalk "^2.4.1"
+    clone-deep "^4.0.0"
+    commander "^2.15.1"
+    deepmerge "^2.1.1"
+    ensure-array "^1.0.0"
+    eol "^0.9.1"
+    esprima "^4.0.0"
+    gulp-sort "^2.0.0"
+    i18next "^11.10.1"
+    lodash "^4.0.0"
+    parse5 "^5.0.0"
+    sortobject "^1.1.1"
+    through2 "^2.0.3"
+    vinyl "^2.2.0"
+    vinyl-fs "^3.0.1"
+
+i18next-xhr-backend@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-2.0.1.tgz#7af735ee1b0c6d4ce49fa5756591040a0fba6db7"
+  integrity sha512-CP0XPjJsTE4hY1rM1KXFYo63Ib61EBLEcTvMDyJwr0vs9p/UTuA3ENCmzSs9+ghZgWSjdOigc0oUERHaxctbsQ==
+
+i18next@^11.10.1:
+  version "11.10.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-11.10.2.tgz#e5f10346f6320ecf15595419926c25255381a56c"
+  integrity sha512-1rowdX8PqrvsdFhYb3v0A/LlIHLQL1HTa4ia29IzhvNAg2fesNV7R1jXibWLmLQdz3FfTB8RuqSqDEjIawXruA==
+
+i18next@^15.0.4:
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-15.0.4.tgz#17ee253ff2cc67c5003065fef2f4196b2d6d8b04"
+  integrity sha512-msRzIP/9Vo6wMbbkFRoosVu5X55vARjfhX3H9Z2avRoDAjIBNsXfpfCVF3hbP/2aMQDNEds3NUuDxE4XhcAMnA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -1714,6 +1951,11 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-negated-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
+  integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -1786,6 +2028,11 @@ is-utf8@^0.2.0, is-utf8@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-valid-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
+  integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -1831,6 +2078,11 @@ istextorbinary@1.0.2:
     binaryextensions "~1.0.0"
     textextensions "~1.0.0"
 
+jquery-i18next@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/jquery-i18next/-/jquery-i18next-1.2.1.tgz#3e4ac5e46632fac21640529f1aa7b68e54f227e8"
+  integrity sha512-UNcw3rgxoKjGEg4w23FEn2h3OlPJU7rPzsgDuXDBZktIzeiVbJohs9Cv9hj8oP8KNfBRKOoErL/OVxg2FaAR4g==
+
 "jquery@1.9.1 - 3", jquery@3.3.1, jquery@>=1.7, jquery@>=1.8:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
@@ -1858,6 +2110,11 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -1913,6 +2170,20 @@ lazy-debug-legacy@0.0.X:
   resolved "https://registry.yarnpkg.com/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz#537716c0776e4cf79e3ed1b621f7658c2911b1b1"
   integrity sha1-U3cWwHduTPeePtG2IfdljCkRsbE=
 
+lazystream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
+  integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
+  dependencies:
+    readable-stream "^2.0.5"
+
+lead@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lead/-/lead-1.0.0.tgz#6f14f99a37be3a9dd784f5495690e5903466ee42"
+  integrity sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=
+  dependencies:
+    flush-write-stream "^1.0.2"
+
 leaflet-control-geocoder@~1.5.8:
   version "1.5.8"
   resolved "https://registry.yarnpkg.com/leaflet-control-geocoder/-/leaflet-control-geocoder-1.5.8.tgz#c52dfbb9be5f6388d683346acb49bf017fd5b6a8"
@@ -1947,6 +2218,11 @@ leaflet-sidebar-v2@nrenner/leaflet-sidebar-v2#dev:
   version "3.0.2"
   resolved "https://codeload.github.com/nrenner/leaflet-sidebar-v2/tar.gz/e9d094b01cb782b86be9038faadc17406c6cdf16"
 
+leaflet-triangle-marker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/leaflet-triangle-marker/-/leaflet-triangle-marker-1.0.1.tgz#0775ee4903c6c0b71b20023dfb295dfc026bc23d"
+  integrity sha512-nK2Wtp5tUPwg9STrE78oKLQJvcDZTMU5i+4la1zhHZKZcjoTl9oVVd0f6keMx+wN70IiHsoDkHCFzIiVcCs9eQ==
+
 leaflet.locatecontrol@^0.60.0:
   version "0.60.0"
   resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.60.0.tgz#fc7be657ca9b7e8b8ba7263e52b0bb902b7cd965"
@@ -1956,15 +2232,16 @@ leaflet.restoreview@makinacorpus/Leaflet.RestoreView#master:
   version "1.0.0"
   resolved "https://codeload.github.com/makinacorpus/Leaflet.RestoreView/tar.gz/9c99464d19d2f25e146326d86639ff37be9cd5a6"
 
-leaflet.stravasegments@*:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/leaflet.stravasegments/-/leaflet.stravasegments-1.1.1.tgz#a021e155e5a235297058520e7b3d69dd3cd7ed0d"
-  integrity sha512-pA2IqQht0/d+B6D4LT4opSP4uAiDKqxWB70zqJ5uO1hz3tdFmVyChxCrUGV41KYLCj0OUslGzTDYpd37vz0Y7w==
+leaflet.stravasegments@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/leaflet.stravasegments/-/leaflet.stravasegments-2.0.3.tgz#0b8a041528a5afc2764e9b45191f56c9af6dedce"
+  integrity sha512-EsyjIpUQj8BEL/JBD4jXHy1VaqqENRUGmM9EyJhuDCmtJWigu0IT7GY9oyuNVj/JCb6HSocm9qInT1tsiZEn1g==
   dependencies:
     "@mapbox/polyline" "^1.0.0"
     font-awesome "4"
     leaflet "^1.3.4"
     leaflet-easybutton "^2.3.0"
+    leaflet-triangle-marker "^1.0.1"
 
 leaflet@^1.0.1, leaflet@^1.3.4:
   version "1.4.0"
@@ -2124,6 +2401,11 @@ lodash@^3.3.1, lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+
+lodash@^4.0.0:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@~1.0.1:
   version "1.0.2"
@@ -2341,7 +2623,7 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
@@ -2352,6 +2634,13 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+
+now-and-later@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.0.tgz#bc61cbb456d79cb32207ce47ca05136ff2e7d6ee"
+  integrity sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=
+  dependencies:
+    once "^1.3.2"
 
 npmfiles@^0.1.1:
   version "0.1.1"
@@ -2400,6 +2689,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.11, object-keys@^1.0.12:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
+
 object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
@@ -2411,6 +2705,16 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.defaults@^1.1.0:
   version "1.1.0"
@@ -2437,7 +2741,7 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -2470,6 +2774,13 @@ ordered-read-streams@^0.1.0:
   resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz#fd565a9af8eb4473ba69b6ed8a34352cb552f126"
   integrity sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=
 
+ordered-read-streams@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz#77c0cb37c41525d64166d990ffad7ec6a0e1363e"
+  integrity sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=
+  dependencies:
+    readable-stream "^2.0.1"
+
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -2501,10 +2812,20 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
+parse5@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -2714,6 +3035,23 @@ publish-release@^1.3.2:
     single-line-log "^0.4.1"
     string-editor "^0.1.0"
 
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pumpify@^1.3.5:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2772,7 +3110,7 @@ read@~1.0.5:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.3.5, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -2823,6 +3161,11 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -2830,6 +3173,23 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+remove-bom-buffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz#c2bf1e377520d324f623892e33c10cac2c252b53"
+  integrity sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==
+  dependencies:
+    is-buffer "^1.1.5"
+    is-utf8 "^0.2.1"
+
+remove-bom-stream@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz#05f1a593f16e42e1fb90ebf59de8e569525f9523"
+  integrity sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=
+  dependencies:
+    remove-bom-buffer "^3.0.0"
+    safe-buffer "^5.1.0"
+    through2 "^2.0.3"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -2916,6 +3276,13 @@ resolve-dir@^1.0.0, resolve-dir@^1.0.1:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
 
+resolve-options@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-options/-/resolve-options-1.1.0.tgz#32bb9e39c06d67338dc9378c0d6d6074566ad131"
+  integrity sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=
+  dependencies:
+    value-or-function "^3.0.0"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -2972,7 +3339,7 @@ rx@^2.4.3:
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.5.3.tgz#21adc7d80f02002af50dae97fd9dbf248755f566"
   integrity sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -2993,7 +3360,7 @@ seiyria-bootstrap-slider@seiyria/bootstrap-slider#^9.8.1:
   version "9.10.0"
   resolved "https://codeload.github.com/seiyria/bootstrap-slider/tar.gz/92612ee5971257631c1d70347806253faad37be4"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -3032,6 +3399,13 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.0.tgz#317b701facce5e742d4c04c64e1d52f957e22b28"
+  integrity sha512-Drg+nOI+ofeuslBf0nulyWLZhK1BZprqNvPJaiB4VvES+9gC6GG+qOVAfuO12zVSgxq9SKevcme7S3uDT6Be8w==
+  dependencies:
+    kind-of "^6.0.2"
 
 sigmund@~1.0.0:
   version "1.0.1"
@@ -3077,6 +3451,13 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+sortobject@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.2.0.tgz#f24dbd1c1eb53013823f4045c5cae75e0aea273a"
+  integrity sha512-b/UBYCIXcloH6NO0CSG+/8dYsDA+egku07g0oeYPBmmt8CS64pORXPYmQ/W65UBGxYz7dTacjWgBVlq/TzxmQQ==
+  dependencies:
+    editions "^2.1.3"
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
@@ -3322,7 +3703,15 @@ textextensions@~1.0.0:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-1.0.2.tgz#65486393ee1f2bb039a60cbba05b0b68bd9501d2"
   integrity sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=
 
-through2@2.X, through2@^2.0.0, through2@^2.0.1, through2@^2.0.3:
+through2-filter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/through2-filter/-/through2-filter-3.0.0.tgz#700e786df2367c2c88cd8aa5be4cf9c1e7831254"
+  integrity sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==
+  dependencies:
+    through2 "~2.0.0"
+    xtend "~4.0.0"
+
+through2@2.X, through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -3379,6 +3768,14 @@ time-stamp@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
+to-absolute-glob@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1865f43d9e74b0822db9f145b78cff7d0f7c849b"
+  integrity sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=
+  dependencies:
+    is-absolute "^1.0.0"
+    is-negated-glob "^1.0.0"
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -3403,6 +3800,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-through@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-through/-/to-through-2.0.0.tgz#fc92adaba072647bc0b67d6b03664aa195093af6"
+  integrity sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=
+  dependencies:
+    through2 "^2.0.3"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
@@ -3469,6 +3873,14 @@ unique-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-1.0.0.tgz#d59a4a75427447d9aa6c91e70263f8d26a4b104b"
   integrity sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=
 
+unique-stream@^2.0.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-2.3.1.tgz#c65d110e9a4adf9a6c5948b28053d9a8d04cbeac"
+  integrity sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==
+  dependencies:
+    json-stable-stringify-without-jsonify "^1.0.1"
+    through2-filter "^3.0.0"
+
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -3529,6 +3941,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+value-or-function@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
+  integrity sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -3551,6 +3968,42 @@ vinyl-fs@^0.3.0:
     strip-bom "^1.0.0"
     through2 "^0.6.1"
     vinyl "^0.4.0"
+
+vinyl-fs@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
+  integrity sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==
+  dependencies:
+    fs-mkdirp-stream "^1.0.0"
+    glob-stream "^6.1.0"
+    graceful-fs "^4.0.0"
+    is-valid-glob "^1.0.0"
+    lazystream "^1.0.0"
+    lead "^1.0.0"
+    object.assign "^4.0.4"
+    pumpify "^1.3.5"
+    readable-stream "^2.3.3"
+    remove-bom-buffer "^3.0.0"
+    remove-bom-stream "^1.2.0"
+    resolve-options "^1.1.0"
+    through2 "^2.0.0"
+    to-through "^2.0.0"
+    value-or-function "^3.0.0"
+    vinyl "^2.0.0"
+    vinyl-sourcemap "^1.1.0"
+
+vinyl-sourcemap@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz#92a800593a38703a8cdb11d8b300ad4be63b3e16"
+  integrity sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=
+  dependencies:
+    append-buffer "^1.0.2"
+    convert-source-map "^1.5.0"
+    graceful-fs "^4.1.6"
+    normalize-path "^2.1.1"
+    now-and-later "^2.0.0"
+    remove-bom-buffer "^3.0.0"
+    vinyl "^2.0.0"
 
 vinyl-sourcemaps-apply@0.2.1, vinyl-sourcemaps-apply@^0.2.0, vinyl-sourcemaps-apply@^0.2.1:
   version "0.2.1"
@@ -3585,7 +4038,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-vinyl@^2.0.0, vinyl@^2.0.1, vinyl@^2.1.0:
+vinyl@^2.0.0, vinyl@^2.0.1, vinyl@^2.1.0, vinyl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
   integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==


### PR DESCRIPTION
Fixes #63. I've used `i18next` + a bunch of plugins:

- `i18next-browser-languagedetector` to detect user language
- `i18next-xhr-backend` to load translations from `.json` files stored on server
- `jquery-i18next` to allow translation for given selector, eg `$('html').localize()`. Maybe we can get rid of this
- `i18next-scanner` to generate .json files automatically from `*.js,index.html`. You can run it via `gulp i18next`.

You can try my branch to test it, you should have French translations if your browser uses this language.

@nrenner please complete the todolist if you see missing items :). Review/feedback are welcome too!

- [x] Add i18n keys for all translatable texts
- [x] Plug with Transifex (pull and push)
- [ ] Should we add a language picker to allow user to pick a different language from his browser preferences?
- [x] translate js leaflet buttons
- [x] translate map layers
- [x] select profile/alternative in navbar