### PR TITLE
Polish texts for translation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -115,20 +115,20 @@
       "custom": "Custom",
       "fastbike": "Fastbike",
       "fastbike-asia-pacific": "Fastbike (Asia Pacific)",
-      "fastbike-lowtraffic": "Fastbike low traffic",
+      "fastbike-lowtraffic": "Fastbike (low traffic)",
       "hiking-beta": "Hiking (beta)",
       "moped": "Moped",
       "rail": "Rail",
       "river": "River",
       "safety": "Safety",
       "shortest": "Shortest",
-      "trekking": "Trekking",
-      "trekking-ignore-cr": "Trekking (ignore cylce routes)",
-      "trekking-noferries": "Trekking (no ferries)",
-      "trekking-nosteps": "Trekking (no steps)",
-      "trekking-steep": "Trekking steep",
-      "vm-forum-liegerad-schnell": "vm-forum-liegerad-schnell",
-      "vm-forum-velomobil-schnell": "vm-forum-velomobil-schnell"
+      "trekking": "Trekking bike",
+      "trekking-ignore-cr": "Trekking bike (ignore cycle routes)",
+      "trekking-noferries": "Trekking bike (no ferries)",
+      "trekking-nosteps": "Trekking bike (no steps)",
+      "trekking-steep": "Trekking bike (steep)",
+      "vm-forum-liegerad-schnell": "Recumbent bike (fast)",
+      "vm-forum-velomobil-schnell": "Velomobile (fast)"
     }
   },
   "sidebar": {


### PR DESCRIPTION
- Add name for vm-forum profiles (see also [Transifex issue](https://www.transifex.com/openstreetmap/brouter-web/translate/#fr/brouter-website/165200325))
- "Trekking bike" instead of just "Trekking" to avoid misinterpretation as hiking
  (as seen in German translation and in the discussion Group)
- consistent use of brackets in profile names

@bagage Are you OK with that? I suppose changes in `en` texts can be just synchronized with transifex without any special consideration?