### PR TITLE
Execute gulp release before pushing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "husky": {
         "hooks": {
-            "pre-commit": "pretty-quick --bail"
+            "pre-commit": "pretty-quick --bail",
+            "pre-push": "gulp"
         }
     },
     "repository": {


### PR DESCRIPTION
To avoid regressions like 7367a7d due to `gulp minify` not supporting ES6? javascript syntax, this starts `gulp` before pushing to repository to ensure that the compilation succeed. Does it sound ok to you?
