### PR TITLE
Use leaflet.restoreview from registry

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,8 @@ var paths = {
     scripts: [
         'node_modules/jquery/dist/jquery.js',
         'node_modules/tether/dist/js/tether.js',
-        'node_modules/async/lib/async.js'
+        'node_modules/async/lib/async.js',
+        'node_modules/leaflet/dist/leaflet-src.js'
     ]
         .concat(
             mainNpmFiles().filter(

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "license": "MIT",
     "browserslist": "> 0.5%, last 2 versions, Firefox ESR, not dead, Explorer >= 10, Android >= 4.1, Safari >= 7, iOS >= 7",
     "dependencies": {
+        "@bagage/leaflet.restoreview": "1.0.1",
         "@mapbox/polyline": "^0.2.0",
         "@turf/turf": "^5.1.6",
         "async": "~0.9.2",
         "bootbox": "~5.1.3",
         "bootstrap": "4.3.1",
         "bootstrap-select": "1.13.0",
+        "bootstrap-slider": "^9.8.1",
         "codemirror": "^5.35.0",
         "d3": "~3.5.5",
         "datatables": "~1.10.16",
@@ -50,12 +52,10 @@
         "leaflet-sidebar-v2": "nrenner/leaflet-sidebar-v2#dev",
         "leaflet-triangle-marker": "^1.0.1",
         "leaflet.locatecontrol": "^0.60.0",
-        "leaflet.restoreview": "makinacorpus/Leaflet.RestoreView#master",
         "leaflet.snogylop": "^0.4.0",
         "leaflet.stravasegments": "2.3.2",
         "mapbbcode": "MapBBCode/mapbbcode#v1.2.0",
         "promise-polyfill": "^8.1.0",
-        "seiyria-bootstrap-slider": "seiyria/bootstrap-slider#^9.8.1",
         "tether": "1.4.5",
         "url-search-params": "~0.5.0",
         "whatwg-fetch": "^3.0.0"
@@ -170,9 +170,6 @@
         "url-search-params": {
             "main": "build/url-search-params.js"
         },
-        "Leaflet.RestoreView": {
-            "main": "leaflet.restoreview.js"
-        },
         "leaflet.stravasegments": {
             "main": "dist/index.js"
         },
@@ -188,7 +185,7 @@
                 "dist/L.Control.Locate.css"
             ]
         },
-        "seiyria-bootstrap-slider": {
+        "bootstrap-slider": {
             "main": [
                 "dist/bootstrap-slider.js",
                 "dist/css/bootstrap-slider.css"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@bagage/leaflet.restoreview@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@bagage/leaflet.restoreview/-/leaflet.restoreview-1.0.1.tgz#29597ad80f6af4c2a4b4d80afe0ca8a6e3d58bb7"
+  integrity sha512-9cdJ7mreceVP8QbE9zUH/AfmYmKAYn9sR2R5bHepUEKpEvZfUevhnHF0qrrDx5tEld8yTrZWURE/xftIQJxzTw==
+
 "@gulp-sourcemaps/map-sources@1.X":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz#890ae7c5d8c877f6d384860215ace9d7ec945bda"
@@ -1573,6 +1578,11 @@ bootstrap-select@1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/bootstrap-select/-/bootstrap-select-1.13.0.tgz#f31d0a23fc6070fd5b17b841bf1ca115ce54775b"
   integrity sha1-8x0KI/xgcP1bF7hBvxyhFc5Ud1s=
+
+bootstrap-slider@^9.8.1:
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz#1103d6bc00cfbfa8cfc9a2599ab518c55643da3f"
+  integrity sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8=
 
 bootstrap@4.3.1, bootstrap@>=3.0.0:
   version "4.3.1"
@@ -3691,10 +3701,6 @@ leaflet.locatecontrol@^0.60.0:
   resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.60.0.tgz#fc7be657ca9b7e8b8ba7263e52b0bb902b7cd965"
   integrity sha1-/HvmV8qbfouLpyY+UrC7kCt82WU=
 
-leaflet.restoreview@makinacorpus/Leaflet.RestoreView#master:
-  version "1.0.0"
-  resolved "https://codeload.github.com/makinacorpus/Leaflet.RestoreView/tar.gz/9c99464d19d2f25e146326d86639ff37be9cd5a6"
-
 leaflet.snogylop@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/leaflet.snogylop/-/leaflet.snogylop-0.4.0.tgz#bc373432edc1da63a8efbcc5a681d398deebd0d3"
@@ -5069,10 +5075,6 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-seiyria-bootstrap-slider@seiyria/bootstrap-slider#^9.8.1:
-  version "9.10.0"
-  resolved "https://codeload.github.com/seiyria/bootstrap-slider/tar.gz/92612ee5971257631c1d70347806253faad37be4"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
It is easier to see if there are updates in dependencies when using NPM registry.

And since upstream package is unmainted, I forked it and published it directly.