### PR TITLE
Always show travel time and energy

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,7 +966,7 @@
                             >
                         </p>
                     </li>
-                    <li hidden>
+                    <li>
                         <div
                             class="text-muted small d-none d-sm-block"
                             data-i18n="footer.travel-time"
@@ -982,7 +982,7 @@
                             >
                         </p>
                     </li>
-                    <li hidden>
+                    <li>
                         <div class="text-muted small d-none d-sm-block">
                             <span data-i18n="footer.total-energy"
                                 >Total Energy</span

--- a/js/control/TrackStats.js
+++ b/js/control/TrackStats.js
@@ -56,12 +56,6 @@ BR.TrackStats = L.Class.extend({
         $('#totaltime').html(formattedTime);
         $('#totalenergy').html(formattedEnergy);
         $('#meanenergy').html(meanEnergy);
-        document.getElementById(
-            'totaltime'
-        ).parentElement.parentElement.hidden = !stats.totalTime;
-        document.getElementById(
-            'totalenergy'
-        ).parentElement.parentElement.hidden = !stats.totalEnergy;
     },
 
     calcStats: function(polyline, segments) {


### PR DESCRIPTION
Now that BRouter 1.5 containing c57eaf9eff23 is released, we can show travel time and energy in the statistics bar right from the start. This avoids the unpleasant change in layout after starting to draw a route, since now the number of available metrics is fixed even before the first call to BRouter.