### PR TITLE
Feature/Center the map to the track when hovering on it

### DIFF
--- a/js/control/TrackMessages.js
+++ b/js/control/TrackMessages.js
@@ -196,6 +196,7 @@ BR.TrackMessages = L.Class.extend({
             edgeLatLngs = trackLatLngs.slice(startIndex, endIndex + 1);
 
         this._selectedEdge = L.polyline(edgeLatLngs, this.options.edgeStyle).addTo(this._map);
+        this._map.panTo(this._selectedEdge.getBounds().getCenter());
     },
 
     _handleHoverOut: function(evt) {


### PR DESCRIPTION
Center the map for the path selected in the data table. Makes it easier to see the path when zoomed in, or when viewing a big route.