### PR TITLE
Add CyclOSM as usable layer

### DIFF
--- a/layers/config/config.js
+++ b/layers/config/config.js
@@ -10,7 +10,7 @@ BR.confLayers.defaultBaseLayers = [
 // worldwide monolingual layers to add as default when browser language matches
 BR.confLayers.languageDefaultLayers = [
     'osm-mapnik-german_style',
-    'osmfr',
+    'cyclosm',
     '1021' // sputnik.ru
 ];
 

--- a/layers/config/overrides.js
+++ b/layers/config/overrides.js
@@ -227,6 +227,11 @@ BR.confLayers.getPropertyOverrides = function() {
         'mapaszlakow-routes': {
             'nameShort': 'Routes PL',
             'mapUrl': 'http://mapaszlakow.eu/#{zoom}/{lat}/{lon}'
-        }
+        },
+        'cyclosm': {
+            'language_code': 'fr',
+            'nameShort': 'CyclOSM',
+            'mapUrl': 'https://dev.{s}.tile.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png'
+        },
     };
 };

--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -2,6 +2,7 @@ BR.confLayers.tree = {
     'base-layers': {
         'worldwide-international': [
             'standard',
+            'cyclosm',
             'OpenTopoMap',
             'Stamen.Terrain',
             'Esri.WorldImagery',

--- a/layers/josm/cyclosm.geojson
+++ b/layers/josm/cyclosm.geojson
@@ -1,0 +1,20 @@
+{
+  "geometry": null,
+  "properties": {
+    "attribution": {
+      "required": true,
+      "text": "Tiles © CyclOSM, Openstreetmap France, data © OpenStreetMap contributors, ODBL",
+      "url": "https://www.openstreetmap.org/"
+    },
+    "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAAUdEVYdFRpdGxlAENvbWJpbmVkIFNoYXBlc3SJBQAAAvdJREFUSIntk1tI03EUx7/n99/mls3StJXZPaOyueyhfOgyL/lgdKGbUBRFYumyKCIiiKT7SxRY6oPZxaRSiKAiCVsWhSzQzBGpLalIMl1G6tqm//1OLxk+NIvwIaLP049zzu98OL8L8J9/HgqWMCdnnwYhSWE+U28vutgft6Tbpktf4AiRaPuqU/a57ub7f1tgWZKTJiVWeXu+7HM5yrosyds3ssAGBr0csGGmZHkFRO8FU1rD/cIDvyWwpOQUMaQVTK0s2E2gTmKES3AEiLb31wnGShASTSPUSg3xhGaP4cRgU4j+hSSEM0Q5EdoBImbWM6NbgDqlSu3OqsIWGZBGnZaXTxndmzouvK8gaqS6N8P86WPxqYxtgwrmpGYvJZZuATb7fP4sZ1XhOgJFAjQZpClXFN6ZsGRHtEYR+WnmLnOvSq3P3hlKLhVfNL7+YChxNOnPFBxfuzyooL6q8A5ApvCAaW3Tk5JuS6ptHUvUMeiwlGoCgIVSqqWZSZ/tjR/0gTvlxWYpMW6SdXPItdLzez55RH2oHrmDHhEIanV1njrXmjONZaB4RqT7sNN+7hEICxgULVk8jzT6xwuF275fXoNRMdwCAJ1C9jcd2thBBcyks1rzNHXVBS5tqBxTUVERiE+yzQfBQcT39CLkLEPTyCqNBoDnC0yHugPeZQAgA1gcM0p9+zPBj1c0OzknjQibvDplq+tuvj/emhvDinrB29O12uUo6wKAXbsyTaFa34u3bo2zxeNJr4mL829+9+aYRsu7Eyb61tsOXL8RVAAA8Sm5Cwmq7XvmKwve33CvqH1gzam8jMQenyhr6QiJFgIyYrjsmx3jrZxq8k962Dhiy8GjpS8H1gf9yb9iT26GJSxMGG9VGh1TFoVqsue0XIuJUKffeBq2Zv+Rqy/+tG9QlmVlDXtwecXtV7fTm04e3GDujytDJWiure3rjFp8My7Km5IY68keO3Ge/f5jZ8eQCQZKxhp6Z7V7QmoePGpwD2X///ylfAN0qT1vK+TL4gAAAABJRU5ErkJggg==",
+    "id": "cyclosm",
+    "max_zoom": 20,
+    "mod-tile-features": true,
+    "name": "CyclOSM",
+    "type": "tms",
+    "url": "https://dev.{switch:a,b,c}.tile.openstreetmap.fr/cyclosm/{zoom}/{x}/{y}.png",
+    "valid-georeference": true,
+    "dataSource": "JOSM"
+  },
+  "type": "Feature"
+}

--- a/layers/josm/extract.js
+++ b/layers/josm/extract.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch');
 const outDir = __dirname;
 
 const includeList = [
+    "cyclosm",
     "osmbe",
     "osmbe-fr",
     "osmbe-nl",


### PR DESCRIPTION
Hi,

This adds the [CyclOSM](https://www.cyclosm.org/) layer as a possible layer offered.

So far, it is hidden in the tree, to provide an easy way to use it for users who want, but not put too much pressure on the servers. We can see afterwards, depending on usage and servers capacity to eventually move it to the default list or to be the default background.

@nrenner One thing I'd like to do (but I could not find how to do it) is use it as the default background for French users (instead of the osm-fr style). Since both osm-fr and cyclosm are currently hosted on the same infrastructure there should not be any impact in terms of performance to do this switch and the CyclOSM render is (I hope) way better for cycling than the osm-fr one.

Best,