### PR TITLE
Dockerfile for building and running brouter-web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:8-alpine as build
-RUN apk add --no-cache git
 RUN mkdir /tmp/brouter-web
 WORKDIR /tmp/brouter-web
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine as build
+RUN apk add --no-cache curl unzip
+RUN curl -L `curl -s https://api.github.com/repos/nrenner/brouter-web/releases/latest | grep browser_download_url | cut -d '"' -f 4` -o brouter-web.zip
+RUN mkdir /tmp/brouter-web
+RUN unzip -d /tmp/brouter-web brouter-web.zip
+
+FROM nginx:alpine
+COPY --from=build /tmp/brouter-web/index.html /usr/share/nginx/html
+COPY --from=build /tmp/brouter-web/dist /usr/share/nginx/html/dist
+VOLUME [ "/usr/share/nginx/html" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM alpine as build
-RUN apk add --no-cache curl unzip
-RUN curl -L `curl -s https://api.github.com/repos/nrenner/brouter-web/releases/latest | grep browser_download_url | cut -d '"' -f 4` -o brouter-web.zip
+FROM node:8-alpine as build
+RUN apk add --no-cache git
 RUN mkdir /tmp/brouter-web
-RUN unzip -d /tmp/brouter-web brouter-web.zip
+WORKDIR /tmp/brouter-web
+COPY . .
+RUN yarn install
+RUN yarn run build
 
 FROM nginx:alpine
 COPY --from=build /tmp/brouter-web/index.html /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This creates a Docker image with the name `brouter-web`.
 To run the previously build Docker image run:
 
       docker run --rm --name brouter-web \
-        -p 127.0.0.1:80:80 \
+        -p 127.0.0.1:8080:80 \
         -v "`pwd`/config.js:/usr/share/nginx/html/config.js" \
         -v "`pwd`/keys.js:/usr/share/nginx/html/keys.js" \
         -v "`pwd`/profiles:/usr/share/nginx/html/profiles" \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ As an alternative to the above online version, the standalone server of BRouter 
 
 2.  download one or more [data file(s)](https://brouter.de/brouter/segments4/) (rd5) into `segments4` directory
 
-### Configure BRouter-Web
+#### Configure BRouter-Web
 
 In the `brouter-web` subdirectory:
 
@@ -52,9 +52,56 @@ In the `brouter-web` subdirectory:
 2.  add your API keys (optional)  
     copy `keys.template.js` to `keys.js` and edit to add your keys
 
-### Run
+#### Run
 
 1.  start `./run.sh`
+
+### Running as Docker container (client only)
+
+brouter-web can be run as a Docker container, making it easy for continous deployment or running locally
+without having to install any build tools.
+
+The `Dockerfile` builds the application inside a NodeJS container and copies the built application into a
+separate Nginx based image. The application runs from a webserver only container serving only static files.
+
+#### Prerequisites
+
+- Docker installed
+- working directory is this repository
+- `config.template.js` copied to `config.js` and modified with a Brouter server, see `BR.conf.host`
+- `keys.template.js` to `keys.js` and add your API keys
+- Optionally create `profiles` directory with `brf` profile files and add path to `config.js`: 
+    
+      BR.conf.profilesUrl = 'profiles/';
+
+
+#### Building Docker image
+
+To build the Docker container run:
+
+      docker build -t brouter-web .
+
+This creates a Docker image with the name `brouter-web`.
+
+#### Running Docker container
+
+To run the previously build Docker image run:
+
+      docker run --rm --name brouter-web \
+        -p 127.0.0.1:80:80 \
+        -v "`pwd`/config.js:/usr/share/nginx/html/config.js" \
+        -v "`pwd`/keys.js:/usr/share/nginx/html/keys.js" \
+        -v "`pwd`/profiles:/usr/share/nginx/html/profiles" \
+        brouter-web
+
+This command does the following:
+
+   1. Runs a container with the name `brouter-web` and removes it automatically after stopping
+   1. Binds port 80 of the container to the host interface 127.0.0.1 on port 8080
+   1. Takes the absolute paths of `config.js`, `keys.js` and `profiles` and mounts them inside the container
+   1. Uses the image `brouter-web` to run as a container
+
+brouter-web should be accessible at http://127.0.0.1:8080.
 
 ## Build
 


### PR DESCRIPTION
Hey @nrenner. This PR adds a multistage Dockerfile which does this:

- build brouter-web in a Docker container running node
- copies the build result into a Docker container running just Nginx making it available at port 80 by default

I have been using this Dockerfile for long time to automatically build my fork of brouter-web on Docker Hub. This makes deployment easy and fast.

Are you interested in adding it to the repo?