### PR TITLE
Disable opening browser on gulp serve?

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -333,7 +333,8 @@ gulp.task(
         server.init({
             server: {
                 baseDir: './'
-            }
+            },
+            open: false
         });
         cb();
     })


### PR DESCRIPTION
When running gulp serve, Browsersync automatically opens the default browser.

I personally would like to disable that, but if you want to keep it, I could probably add an env variable check.

@bagage @Phyks what is your preference?