### PR TITLE
Add config option for initial map position and zoom level

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -30,6 +30,10 @@
         //BR.conf.profilesUrl = 'file://YOUR_PATH_TO/profiles2/';
     }
 
+    // Set the initial position and zoom level of the map
+    BR.conf.initialMapLocation = [50.99, 9.86];
+    BR.conf.initialMapZoom = 5;
+
     BR.conf.profiles = [
         'trekking',
         'fastbike',

--- a/js/Map.js
+++ b/js/Map.js
@@ -19,7 +19,7 @@ BR.Map = {
             })
             .addTo(map);
         if (!map.restoreView()) {
-            map.setView([50.99, 9.86], 5);
+            map.setView(BR.conf.initialMapLocation, BR.conf.initialMapZoom);
         }
 
         // two attribution lines by adding two controls, prevents ugly wrapping on


### PR DESCRIPTION
When I set up my own instance of brouter-web, I wanted to change the default map location closer to where I live. I had to spend a little bit of time looking through the source code to find where I could change this. I think making this a configuration option would make it easier for people to change the default map location in the future.