### PR TITLE
Privacy link relative path

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
                             <a href="https://brouter.de/brouter/segments4/" target="_blank">data files</a>.
                         </p>
                         <p data-i18n="[html]about.details">
-                            <i><a href="https://brouter.de/privacypolicy.html" target="_blank">Privacy Policy</a></i
+                            <i><a href="/privacypolicy.html" target="_blank">Privacy Policy</a></i
                             >,
                             <i
                                 ><a href="https://github.com/nrenner/brouter-web#credits-and-licenses" target="_blank"


### PR DESCRIPTION
The privacy link now is relative to the site that it is hosted on

When opening the about page at brouter-web the privacy link left down in the corner is a relative one to https://brouter.de/privacypolicy.html. When running an own instance I think it should link the that page, because the operator could have other terms, for example time for saving logs. So you shoud change that to a relative path to /privacypolicy.html so every operator can have another text.
You could also include a standard privacypolicy.html and put it to /brouter-web/privacypolicy.html so it can be customized if needed.