### PR TITLE
Fix: Profile params of type 'select' ignored default value from profile

### DIFF
--- a/js/control/Profile.js
+++ b/js/control/Profile.js
@@ -260,6 +260,9 @@ BR.Profile = L.Evented.extend({
                 Object.keys(paramValues).forEach(function(paramValue) {
                     var option = document.createElement('option');
                     option.value = paramValue;
+                    if (paramValue == params[param].value) {
+                        option.selected = true;
+                    }
                     option.append(paramValues[paramValue]);
                     select.appendChild(option);
                 });


### PR DESCRIPTION
Hi,

happens on turnInstructionMode - they are always '0' regardless of setting in the profile code.