### PR TITLE
Allow to mute route display

### DIFF
--- a/js/control/OpacitySlider.js
+++ b/js/control/OpacitySlider.js
@@ -44,6 +44,33 @@ BR.OpacitySlider = L.Class.extend({
         this.getElement().title = this.options.title;
 
         this.options.callback(value / 100);
+
+        if (this.options.muteKeyCode) {
+            L.DomEvent.addListener(document, 'keydown', this._keydownListener, this);
+            L.DomEvent.addListener(document, 'keyup', this._keyupListener, this);
+        }
+    },
+
+    _keydownListener: function(e) {
+        // Suppress shortcut handling when a text input field is focussed
+        if (document.activeElement.type == 'text' || document.activeElement.type == 'textarea') {
+            return;
+        }
+
+        if (e.keyCode === this.options.muteKeyCode && !e.repeat) {
+            this.options.callback(0);
+        }
+    },
+
+    _keyupListener: function(e) {
+        // Suppress shortcut handling when a text input field is focussed
+        if (document.activeElement.type == 'text' || document.activeElement.type == 'textarea') {
+            return;
+        }
+
+        if (e.keyCode === this.options.muteKeyCode && !e.repeat) {
+            this.options.callback(this.input.val() / 100);
+        }
     },
 
     getElement: function() {

--- a/js/index.js
+++ b/js/index.js
@@ -284,6 +284,7 @@
             new BR.OpacitySliderControl({
                 id: 'route',
                 title: i18next.t('map.opacity-slider'),
+                muteKeyCode: 77, // m
                 callback: L.bind(routing.setOpacity, routing)
             })
         );


### PR DESCRIPTION
Having used Komoot before, I really like their feature to "mute" the route display -- especially since I configured it to full opacity and different color (I struggle to see the slightly transparent magenta line well).

So this PR adds the ability to temporarily mute/hide the route, by holding down the "m" key.

I've added it to the `OpacitySlider` input, even so it's not really a feature of the slider itself. However it's currently the only place to track the current opacity value and I didn't want to scatter responsibilities there. Let me know if you see things differently