### PR TITLE
add docker-compose tasks for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,21 +9,35 @@ BRouter is heavily based on the following libraries:
 
 ## Install dependencies
 
-    yarn
+```sh
+yarn
+```
 
 ## Build
 
 ```sh
-    #for development
-    yarn build debug
+#for development
+yarn build debug
 
-    #for release
-    yarn build
+#for release
+yarn build
 ```
 
 ## Develop
 
-    yarn serve
+```sh
+yarn serve
+```
+
+### Develop with Docker
+
+```sh
+#to install dependencies
+docker-compose run --rm install
+
+#to serve for development
+docker-compose run --rm serve
+```
 
 ## Translations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+    ## usage: docker-compose run --rm serve
+    ##      : docker-compose up (-d) serve
+    serve:
+        command: yarn serve
+        image: node:lts
+        ports:
+            - 3000:3000
+        user: '1000'
+        volumes:
+            - ./:/src
+        working_dir: /src
+
+    ## usage: docker-compose run --rm install
+    install:
+        command: yarn install
+        image: node:lts
+        user: '1000'
+        volumes:
+            - ./:/src
+        working_dir: /src


### PR DESCRIPTION
I usually try to avoid installing tools for development processes.

That PR enables everyone to use docker(-compose) instead of manually installing node/npm and yarn.