### PR TITLE
Improve hiding/showing elevation button and chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1009,14 +1009,14 @@
 
         <div class="collapse" id="elevation-chart"></div>
 
-        <footer>
-            <div id="stats-info">
+        <footer class="flexrow">
+            <div id="stats-info" class="flexgrow">
                 <div>
                     <span class="fa fa-info-circle"></span>
                     <span data-i18n="footer.stats-info">Start drawing a route to get stats.</span>
                 </div>
             </div>
-            <div id="stats-container" class="flexrow">
+            <div id="stats-container" class="flexrow flexgrow">
                 <ul id="stats">
                     <li>
                         <div class="text-muted small d-none d-md-block" data-i18n="footer.distance">
@@ -1096,23 +1096,23 @@
                         </p>
                     </li>
                 </ul>
-
-                <button
-                    class="btn btn-outline-secondary btn-sm"
-                    type="button"
-                    data-toggle="collapse"
-                    data-target="#elevation-chart"
-                    aria-controls="elevation-chart"
-                    id="elevation-btn"
-                    aria-expanded="false"
-                    aria-label="Toggle elevation chart"
-                    data-i18n="[title]keyboard.generic-shortcut"
-                    data-i18n-options='{ "action": "$t(footer.elevation-chart)", "key": "E" }'
-                    title="Toggle elevation chart"
-                >
-                    <span class="fa fa-area-chart"></span>
-                </button>
             </div>
+
+            <button
+                class="btn btn-outline-secondary btn-sm"
+                type="button"
+                data-toggle="collapse"
+                data-target="#elevation-chart"
+                aria-controls="elevation-chart"
+                id="elevation-btn"
+                aria-expanded="false"
+                aria-label="Toggle elevation chart"
+                data-i18n="[title]keyboard.generic-shortcut"
+                data-i18n-options='{ "action": "$t(footer.elevation-chart)", "key": "E" }'
+                title="Toggle elevation chart"
+            >
+                <span class="fa fa-area-chart"></span>
+            </button>
         </footer>
 
         <script>

--- a/js/control/TrackStats.js
+++ b/js/control/TrackStats.js
@@ -3,15 +3,11 @@ BR.TrackStats = L.Class.extend({
         if (segments.length == 0) {
             $('#stats-container').hide();
             $('#stats-info').show();
-            this.shouldRestoreChart = $('#elevation-chart').hasClass('show');
-            $('#elevation-chart').collapse('hide');
             return;
         }
 
         $('#stats-container').show();
         $('#stats-info').hide();
-        if (this.shouldRestoreChart === true) $('#elevation-chart').collapse('show');
-        this.shouldRestoreChart = undefined;
 
         var stats = this.calcStats(polyline, segments),
             length1 = L.Util.formatNum(stats.trackLength / 1000, 1).toLocaleString(),

--- a/js/index.js
+++ b/js/index.js
@@ -420,38 +420,11 @@
             urlHash
         );
 
+        // listener and initCollapse here and not in onAdd, as addBelow calls addTo (-> onAdd) on resize
         $(window).resize(function() {
             elevation.addBelow(map);
         });
-
-        $('#elevation-chart').on('show.bs.collapse', function() {
-            $('#elevation-btn').addClass('active');
-        });
-        $('#elevation-chart').on('hidden.bs.collapse', function() {
-            $('#elevation-btn').removeClass('active');
-            // we must fetch tiles that are located behind elevation-chart
-            map._onResize();
-        });
-
-        var onHide = function() {
-            if (this.id && BR.Util.localStorageAvailable()) {
-                localStorage.removeItem(this.id);
-            }
-        };
-        var onShow = function() {
-            if (this.id && BR.Util.localStorageAvailable()) {
-                localStorage[this.id] = 'true';
-            }
-        };
-        // on page load, we want to restore collapsible elements from previous usage
-        $('.collapse')
-            .on('hidden.bs.collapse', onHide)
-            .on('shown.bs.collapse', onShow)
-            .each(function() {
-                if (this.id && BR.Util.localStorageAvailable() && localStorage[this.id] === 'true') {
-                    $(this).collapse('show');
-                }
-            });
+        elevation.initCollapse(map);
     }
 
     i18next.on('languageChanged', function(detectedLanguage) {

--- a/js/plugin/Elevation.js
+++ b/js/plugin/Elevation.js
@@ -56,12 +56,13 @@ BR.Elevation = L.Control.Elevation.extend({
     },
 
     initCollapse: function(map) {
+        var self = this;
         var onHide = function() {
             $('#elevation-btn').removeClass('active');
             // we must fetch tiles that are located behind elevation-chart
             map._onResize();
 
-            if (this.id && BR.Util.localStorageAvailable()) {
+            if (this.id && BR.Util.localStorageAvailable() && !self.shouldRestoreChart) {
                 localStorage.removeItem(this.id);
             }
         };
@@ -78,7 +79,7 @@ BR.Elevation = L.Control.Elevation.extend({
             .on('shown.bs.collapse', onShow)
             .each(function() {
                 if (this.id && BR.Util.localStorageAvailable() && localStorage[this.id] === 'true') {
-                    $(this).collapse('show');
+                    self.shouldRestoreChart = true;
                 }
             });
     },
@@ -93,9 +94,17 @@ BR.Elevation = L.Control.Elevation.extend({
         }
 
         if (track && track.getLatLngs().length > 0) {
+            if (this.shouldRestoreChart === true) $('#elevation-chart').collapse('show');
+            this.shouldRestoreChart = undefined;
+
             this.addData(track.toGeoJSON(), layer);
 
             layer.on('mouseout', this._hidePositionMarker.bind(this));
+        } else {
+            if ($('#elevation-chart').hasClass('show')) {
+                this.shouldRestoreChart = true;
+            }
+            $('#elevation-chart').collapse('hide');
         }
     },
 

--- a/js/plugin/Elevation.js
+++ b/js/plugin/Elevation.js
@@ -55,6 +55,34 @@ BR.Elevation = L.Control.Elevation.extend({
         setParent(this.getContainer(), document.getElementById('elevation-chart'));
     },
 
+    initCollapse: function(map) {
+        var onHide = function() {
+            $('#elevation-btn').removeClass('active');
+            // we must fetch tiles that are located behind elevation-chart
+            map._onResize();
+
+            if (this.id && BR.Util.localStorageAvailable()) {
+                localStorage.removeItem(this.id);
+            }
+        };
+        var onShow = function() {
+            $('#elevation-btn').addClass('active');
+
+            if (this.id && BR.Util.localStorageAvailable()) {
+                localStorage[this.id] = 'true';
+            }
+        };
+        // on page load, we want to restore collapse state from previous usage
+        $('#elevation-chart')
+            .on('hidden.bs.collapse', onHide)
+            .on('shown.bs.collapse', onShow)
+            .each(function() {
+                if (this.id && BR.Util.localStorageAvailable() && localStorage[this.id] === 'true') {
+                    $(this).collapse('show');
+                }
+            });
+    },
+
     update: function(track, layer) {
         this.clear();
 


### PR DESCRIPTION
Fixes #320

Always show the elevation button, so the user always stays in control. And I personally prefer not to hide such basic controls.

Also improves automatic hiding of the elevation graph when empty by considering additional cases:
- don't show empty on load, postpone to update
- don't store state when hidden because empty
- flag got reset when deleting and adding first waypoint
