### PR TITLE
Fix color coding by cost. Closes #340.

### DIFF
--- a/js/plugin/RoutingPathQuality.js
+++ b/js/plugin/RoutingPathQuality.js
@@ -68,16 +68,15 @@ BR.RoutingPathQuality = L.Control.extend({
                         outlineColor: 'dimgray',
                         renderer: renderer
                     },
-                    valueFunction: function(latLng, prevLatLng) {
+                    valueFunction: function(latLng) {
                         var feature = latLng.feature;
-                        var distance = Math.min(prevLatLng.distanceTo(latLng), 1) / 1000; // in km
-                        return (
-                            feature.cost.perKm +
-                            (feature.cost.elev +
-                             feature.cost.turn +
-                             feature.cost.node +
-                             feature.cost.initial) / distance
-                        );
+                        var cost = feature.cost.perKm;
+                        if (feature.distance > 0) {
+                            cost +=
+                                (feature.cost.elev + feature.cost.turn + feature.cost.node + feature.cost.initial) /
+                                feature.distance;
+                        }
+                        return cost;
                     }
                 })
             }

--- a/js/plugin/RoutingPathQuality.js
+++ b/js/plugin/RoutingPathQuality.js
@@ -71,10 +71,11 @@ BR.RoutingPathQuality = L.Control.extend({
                     valueFunction: function(latLng) {
                         var feature = latLng.feature;
                         var cost = feature.cost.perKm;
-                        if (feature.distance > 0) {
+                        var distance = feature.distance / 1000; // in km
+                        if (distance > 0) {
                             cost +=
                                 (feature.cost.elev + feature.cost.turn + feature.cost.node + feature.cost.initial) /
-                                feature.distance;
+                                distance;
                         }
                         return cost;
                     }

--- a/js/plugin/RoutingPathQuality.js
+++ b/js/plugin/RoutingPathQuality.js
@@ -68,14 +68,15 @@ BR.RoutingPathQuality = L.Control.extend({
                         outlineColor: 'dimgray',
                         renderer: renderer
                     },
-                    valueFunction: function(latLng) {
+                    valueFunction: function(latLng, prevLatLng) {
                         var feature = latLng.feature;
+                        var distance = Math.min(prevLatLng.distanceTo(latLng), 1) / 1000; // in km
                         return (
                             feature.cost.perKm +
-                            feature.cost.elev +
-                            feature.cost.turn +
-                            feature.cost.node +
-                            feature.cost.initial
+                            (feature.cost.elev +
+                             feature.cost.turn +
+                             feature.cost.node +
+                             feature.cost.initial) / distance
                         );
                     }
                 })

--- a/js/router/BRouter.js
+++ b/js/router/BRouter.js
@@ -236,6 +236,7 @@ L.BRouter = L.Class.extend({
                 node: parseInt(featureMessage[7]),
                 initial: parseInt(featureMessage[8])
             },
+            distance: parseInt(featureMessage[3]),
             wayTags: featureMessage[9],
             nodeTags: featureMessage[10]
         };


### PR DESCRIPTION
This fixes color coding by cost (#340), making sure it is relative to the length of the path.

Two points where I am not quite sure:
* I used the same technique as the `incline` provider to compute the distance, but this is probably inaccurate: instead of the distance between the start and the end point, the length of the path should probably be used. I suspect this is available in the `feature.cost` object, no?
* It is not clear to me whether the `initial` and `node` costs should also be divided by the distance (they were all 0 in my example). I am sure the `elev` and `turn` costs should be divided since they seem to be integrated over the whole segment.