### PR TITLE
Fix limit area issues

### DIFF
--- a/js/control/Message.js
+++ b/js/control/Message.js
@@ -50,6 +50,8 @@ BR.Message = L.Class.extend({
             err = i18next.t('warning.invalid-route-to');
         } else if (err == 'from-position not mapped in existing datafile\n') {
             err = i18next.t('warning.invalid-route-from');
+        } else if (err && err.startsWith('null description for: ')) {
+            err = i18next.t('warning.no-route-found');
         }
         this._show(err, 'error');
     },

--- a/js/index.js
+++ b/js/index.js
@@ -34,7 +34,7 @@
             drawButton,
             deleteRouteButton,
             pois,
-            circleGo,
+            circlego,
             urlHash;
 
         // By default bootstrap-select use glyphicons
@@ -260,8 +260,6 @@
         });
 
         pois = new BR.PoiMarkers(routing);
-        circleGo = new BR.CircleGoArea(routing, nogos, pois);
-        pois.circlego = circleGo;
 
         exportRoute = new BR.Export(router, pois);
 
@@ -322,18 +320,22 @@
 
         nogos.addTo(map);
 
-        var shouldAddCircleGo = false;
+        var circlegoRadius = null;
         var lang = i18next.languages.length && i18next.languages[0];
 
         if (lang.startsWith('fr')) {
-            circleGo.options.radius = 20000;
-            shouldAddCircleGo = true;
+            circlegoRadius = 20000;
         }
 
-        if (shouldAddCircleGo) circleGo.addTo(map);
+        if (circlegoRadius != null) {
+            circlego = new BR.CircleGoArea(routing, nogos, pois);
+            circlego.options.radius = circlegoRadius;
+            pois.circlego = circlego;
+            circlego.addTo(map);
+        }
 
         var buttons = [drawButton, reverseRouteButton, nogos.getButton()];
-        if (shouldAddCircleGo) buttons.push(circleGo.getButton());
+        if (circlegoRadius) buttons.push(circlego.getButton());
         buttons.push(deletePointButton, deleteRouteButton);
 
         L.easyBar(buttons).addTo(map);
@@ -392,10 +394,10 @@
             var opts = router.parseUrlParams(url2params(url));
             router.setOptions(opts);
             routingOptions.setOptions(opts);
-            if (opts.circlego) {
+            if (circlego && opts.circlego) {
                 // must be done before nogos!
-                circleGo.options.radius = opts.circlego[2];
-                circleGo.setCircle([opts.circlego[0], opts.circlego[1]]);
+                circlego.options.radius = opts.circlego[2];
+                circlego.setCircle([opts.circlego[0], opts.circlego[1]]);
             }
             nogos.setOptions(opts);
             profile.update(opts);
@@ -423,7 +425,7 @@
         // this callback is used to append anything in URL after L.Hash wrote #map=zoom/lat/lng/layer
         urlHash.additionalCb = function() {
             var url = router
-                .getUrl(routing.getWaypoints(), pois.getMarkers(), circleGo.getCircle(), null)
+                .getUrl(routing.getWaypoints(), pois.getMarkers(), circlego ? circlego.getCircle() : null, null)
                 .substr('brouter?'.length + 1);
 
             // by default brouter use | as separator. To make URL more human-readable, we remplace them with ; for users

--- a/js/index.js
+++ b/js/index.js
@@ -394,11 +394,6 @@
             var opts = router.parseUrlParams(url2params(url));
             router.setOptions(opts);
             routingOptions.setOptions(opts);
-            if (circlego && opts.circlego) {
-                // must be done before nogos!
-                circlego.options.radius = opts.circlego[2];
-                circlego.setCircle([opts.circlego[0], opts.circlego[1]]);
-            }
             nogos.setOptions(opts);
             profile.update(opts);
 
@@ -409,6 +404,10 @@
             }
             if (opts.pois) {
                 pois.setMarkers(opts.pois);
+            }
+            if (circlego && opts.circlego) {
+                circlego.options.radius = opts.circlego[2];
+                circlego.setCircle([opts.circlego[0], opts.circlego[1]], opts.polylines != null);
             }
         };
 

--- a/js/plugin/CircleGoArea.js
+++ b/js/plugin/CircleGoArea.js
@@ -173,6 +173,9 @@ BR.CircleGoArea = L.Control.extend({
         }
         inner.push(inner[0]);
 
+        /* hack: it seems there is a bug when using a single closed ring line,
+         cf. https://github.com/nrenner/brouter-web/issues/349#issue-755514458
+         so instead we use 2 half rings to ensure we properly close the area */
         return {
             type: 'FeatureCollection',
             features: [
@@ -181,7 +184,15 @@ BR.CircleGoArea = L.Control.extend({
                     properties: {},
                     geometry: {
                         type: 'LineString',
-                        coordinates: inner
+                        coordinates: inner.slice(n / 2 - 1)
+                    }
+                },
+                {
+                    type: 'Feature',
+                    properties: {},
+                    geometry: {
+                        type: 'LineString',
+                        coordinates: inner.slice(0, n / 2 + 1)
                     }
                 }
             ]

--- a/js/plugin/CircleGoArea.js
+++ b/js/plugin/CircleGoArea.js
@@ -96,10 +96,10 @@ BR.CircleGoArea = L.Control.extend({
     },
 
     onMapClick: function(e) {
-        this.setCircle([e.latlng.lng, e.latlng.lat]);
+        this.setCircle([e.latlng.lng, e.latlng.lat], false);
     },
 
-    setCircle: function(center) {
+    setCircle: function(center, skipNogo) {
         var self = this;
         var icon = L.VectorMarkers.icon({
             icon: 'home',
@@ -119,7 +119,7 @@ BR.CircleGoArea = L.Control.extend({
 
         this.clear();
         marker.addTo(this.circleLayer);
-        this.setNogoCircle(center);
+        if (!skipNogo) this.setNogoCircle(center);
         this.draw(false);
     },
 

--- a/js/plugin/CircleGoArea.js
+++ b/js/plugin/CircleGoArea.js
@@ -88,6 +88,7 @@ BR.CircleGoArea = L.Control.extend({
         if (center) {
             var polygon = this.circleToPolygon(center, this.options.radius);
             $('#nogoJSON').val(JSON.stringify(polygon));
+            $('#nogoBuffer').val(0);
             this.nogos.uploadNogos();
         } else {
             this.nogos.clear();
@@ -164,7 +165,7 @@ BR.CircleGoArea = L.Control.extend({
     },
 
     circleToPolygon: function(center, radius, numberOfSegments) {
-        var n = numberOfSegments ? numberOfSegments : 64;
+        var n = numberOfSegments ? numberOfSegments : 32;
 
         var inner = [];
         for (var i = 0; i < n; ++i) {

--- a/js/plugin/POIMarkers.js
+++ b/js/plugin/POIMarkers.js
@@ -59,7 +59,7 @@ BR.PoiMarkers = L.Control.extend({
         this.drawButton.state(enable ? 'deactivate-poi' : 'activate-poi');
         if (enable) {
             this.routing.draw(false);
-            this.circlego.draw(false);
+            if (this.circlego) this.circlego.draw(false);
             this.map.on('click', this.onMapClick, this);
             L.DomUtil.addClass(this.map.getContainer(), 'pois-draw-enabled');
         } else {


### PR DESCRIPTION
> 1. Error when circleGo not added (language not fr)

Indeed, I massively modified the code and forgot to retest that at the end, my bad.

> 2. When removing the zone, all no-go areas are also deleted: 

Yes, I couldn't find an easy way to only remove the circleGo area since I don't know which one it is. I pushed a minor to fix to avoid erasing nogo areas on URL load, but once you set/move the home icon, it'll still remove nogo areas. Do you see any workaround here?

> 3. Sometimes it does find a way out, maybe polyline is not a closed ring? 

Nice catch :). The ring should be closed, not sure what's happening here; I reduced the ring segments from 64 to 32 (still looks OK) and the issue went away.. maybe 64 points is too much for turf or brouter engine? 
 
Fix #349 