### PR TITLE
Show inverted polygon for allowed zone

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -200,6 +200,9 @@ input#trackname:focus:invalid {
 .circlego-draw-enabled {
     cursor: pointer;
 }
+.circlego-outside {
+    cursor: not-allowed;
+}
 
 #map {
     /* center error message horizontally */


### PR DESCRIPTION
Out of interest I experimented with adding an inverted polygon for the limited area, as a potential addition to #347.

- shows the outside area in a darker shade
- shows a `not-allowed` cursor
- stops clicks on the polygon and thus prevents adding markers outside the area - but cannot avoid dragging markers out

![grafik](https://user-images.githubusercontent.com/1092030/101194416-448f4d80-365e-11eb-8a90-8bc791c6b6d4.png)

@bagage what do you think, would that be a useful addition (I don't mind if not)?
