### PR TITLE
add support for allowed 15 km zone when German localization is active

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -328,6 +328,10 @@
             circlegoRadius = 20000;
         }
 
+        if (lang.startsWith('de')) {
+            circlegoRadius = 15000;
+        }
+
         if (circlegoRadius != null) {
             circlego = new BR.CircleGoArea(routing, nogos, pois);
             circlego.options.radius = circlegoRadius;


### PR DESCRIPTION
Germany is about to restrict movement to a 15 km radius around the home town. This commit enables the "allowed zone" icon for the German localization of BRouter-Web and sets it to a radius of 15,000 meters.