### PR TITLE
Update docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine as build
+FROM node:10-buster as build
 RUN mkdir /tmp/brouter-web
 WORKDIR /tmp/brouter-web
 COPY . .


### PR DESCRIPTION
We're running a copy based on Docker and found that some time after 0.13 node 8 stopped working. After some back and forth with different versions, this is one that seems to work. Alpine unfortunately doesn't because git is too outdated for `husky`.