### PR TITLE
Use plural form when multiple overlays are active

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,13 +850,9 @@
                                 ><span data-i18n="sidebar.layers.title">Layers</span>
                             </h1>
                             <div id="layers-control-wrapper"></div>
-                            <div class="leaflet-control-layers-separator"></div>
-                            <div>
-                                <label
-                                    id="leaflet-control-layers-overlays-opacity-slider"
-                                    data-i18n="sidebar.layers.overlay-opacity"
-                                    >Overlay transparency</label
-                                >
+                            <div id="leaflet-control-layers-overlays-opacity-slider">
+                                <div class="leaflet-control-layers-separator"></div>
+                                <label data-i18n="sidebar.layers.overlay-opacity">Overlay transparency</label>
                             </div>
                             <div class="leaflet-control-layers-separator"></div>
                             <div id="layers-button-group">

--- a/js/control/LayersTab.js
+++ b/js/control/LayersTab.js
@@ -26,12 +26,14 @@ BR.LayersTab = BR.ControlLayers.extend({
         BR.ControlLayers.prototype.onAdd.call(this, map);
 
         map.on('baselayerchange overlayadd overlayremove', this.storeActiveLayers, this);
+        map.on('overlayadd overlayremove', this.updateOpacityLabel, this);
     },
 
     onRemove: function (map) {
         BR.ControlLayers.prototype.onRemove.call(this, map);
 
         map.off('baselayerchange overlayadd overlayremove', this.storeActiveLayers, this);
+        map.off('overlayadd overlayremove', this.updateOpacityLabel, this);
     },
 
     initOpacitySlider: function (map) {
@@ -470,6 +472,17 @@ BR.LayersTab = BR.ControlLayers.extend({
                     }
                 }
             }
+        }
+    },
+
+    updateOpacityLabel: function () {
+        var slider = $('#leaflet-control-layers-overlays-opacity-slider');
+        var overlaysCount = this.getActiveLayers().length - 1;
+        if (overlaysCount === 0) {
+            slider.hide();
+        } else {
+            slider.show();
+            slider.children()[1].innerText = i18next.t('sidebar.layers.overlay-opacity', { count: overlaysCount });
         }
     },
 });

--- a/locales/en.json
+++ b/locales/en.json
@@ -240,6 +240,7 @@
       "optional": "Add or remove optional layers",
       "optional-layers": "More",
       "overlay-opacity": "Overlay transparency",
+      "overlay-opacity_plural": "Overlays transparency",
       "table": {
         "URL": "URL",
         "empty": "No custom layer configured yet.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -238,6 +238,7 @@
       "optional": "Ajouter ou supprimer des calques optionnels",
       "optional-layers": "Plus",
       "overlay-opacity": "Transparence de la surcouche",
+      "overlay-opacity_plural": "Transparence des surcouches",
       "table": {
         "URL": "URL",
         "empty": "Aucun calque personnel trouvé.",


### PR DESCRIPTION
It is somewhat misleading to have a singular form for overlay transparency slider, while it actually affects all overlays currently active - so this is just modifying the label dynamically depending on the number of active overlays (or hide the slider completely if there are no overlays active).