### PR TITLE
Gray out unselectable layers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -783,3 +783,8 @@ table.dataTable.display tbody tr:hover.selected {
     left: 50%;
     transform: translate(-50%, -50%);
 }
+
+/* Gray out non selectable layers (zoom out of scope, etc.) */
+.leaflet-control-layers-selector[disabled] ~ span {
+    color: #777;
+}


### PR DESCRIPTION
When you zoom too much, some layers are not available/not clickable, but previously there was no distinction. Now it looks like:

![image](https://user-images.githubusercontent.com/1451988/110301581-87174c00-7ff8-11eb-807d-fa5fddded841.png)
