### PR TITLE
Add (Overpass based) POI layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,5 @@ Copyright (c) 2018 Norbert Renner and [contributors](https://github.com/nrenner/
     Copyright (c) 2014-2021 Denis Pushkarev; [MIT License](https://github.com/zloirock/core-js/blob/master/LICENSE)
 -   [regenerator-runtime](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)  
     Copyright (c) 2014-present, Facebook, Inc.; [MIT License](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/LICENSE)
+-   [overpass-layer](https://github.com/plepe/overpass-layer)
+    Copyright (c) 2020 Stephan Bösch-Plepelits; [MIT License](https://github.com/plepe/overpass-layer/blob/master/LICENSE)

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    presets: [['@babel/preset-env', {}]],
+    sourceType: 'script',
+    exclude: [/node_modules\/(?!overpass-layer\/).*/],
+};

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,0 @@
-{
-    "presets": [["@babel/preset-env", {}]],
-    "sourceType": "script",
-    "exclude": ["node_modules/**"]
-}

--- a/css/style.css
+++ b/css/style.css
@@ -54,6 +54,16 @@ table.dataTable {
     vertical-align: top;
 }
 
+.overpass-layer-icon i {
+    position: absolute;
+    top: 7px;
+    left: 7px;
+    color: white;
+    margin: auto;
+    display: inline-block;
+    font-size: 11px;
+}
+
 /* wrap toolbar controls */
 .leaflet-top.leaflet-left {
     bottom: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -54,16 +54,6 @@ table.dataTable {
     vertical-align: top;
 }
 
-.overpass-layer-icon i {
-    position: absolute;
-    top: 7px;
-    left: 7px;
-    color: white;
-    margin: auto;
-    display: inline-block;
-    font-size: 11px;
-}
-
 /* wrap toolbar controls */
 .leaflet-top.leaflet-left {
     bottom: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -45,6 +45,15 @@ table.dataTable {
     flex: auto;
 }
 
+/* reduce title font size in overpass popups */
+.leaflet-popup-content h1 {
+    font-size: 1.2rem;
+}
+
+.overpass-tags th {
+    vertical-align: top;
+}
+
 /* wrap toolbar controls */
 .leaflet-top.leaflet-left {
     bottom: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -224,11 +224,14 @@ input#trackname:focus:invalid {
     /* map click/drag selects text in controls in Firefox because of display flex */
     -moz-user-select: none;
 }
-.leaflet-control-container,
-#message .alert {
+.leaflet-control-container {
     -moz-user-select: text;
 }
-#message {
+#notification_jar .alert {
+    -moz-user-select: text;
+    margin-bottom: 10px;
+}
+#notification_jar {
     position: absolute;
     margin: 10px 46px; /* 10 + 26 + 10 */
     z-index: 3001;

--- a/index.html
+++ b/index.html
@@ -240,6 +240,14 @@
                         </button>
                         <button
                             type="button"
+                            id="custom_layers_add_overpass"
+                            class="btn btn-success"
+                            data-i18n="layers.add-overpass"
+                        >
+                            Add overpass query
+                        </button>
+                        <button
+                            type="button"
                             id="custom_layers_remove"
                             class="btn btn-danger"
                             data-i18n="layers.remove-selection"

--- a/index.html
+++ b/index.html
@@ -203,24 +203,26 @@
                         </button>
                     </div>
                     <div class="modal-body">
-                        <input
-                            class="form-control"
-                            type="text"
-                            id="layer_name"
-                            spellcheck="true"
-                            wrap="off"
-                            data-i18n="[placeholder]layers.placeholder-layer-name"
-                            placeholder="Custom layer name. (ex: OpenStreetMap)"
-                        />
-                        <input
-                            class="form-control"
-                            type="text"
-                            id="layer_url"
-                            spellcheck="false"
-                            wrap="off"
-                            data-i18n="[placeholder]layers.placeholder-layer-url"
-                            placeholder="Custom layer URL. (ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)"
-                        />
+                        <div class="form-group">
+                            <label for="layer_name" data-i18n="layers.custom-layer-name-label">Custom layer name</label>
+                            <input class="form-control" type="text" id="layer_name" spellcheck="true" wrap="off" />
+                            <p class="help-block" data-i18n="layers.custom-layer-name-helptext">ex: OpenStreetMap</p>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="layer_name" data-i18n="layers.custom-layer-url-label"
+                                >Custom layer URL/Query</label
+                            >
+                            <input class="form-control" type="text" id="layer_url" spellcheck="false" wrap="off" />
+                            <p class="help-block">
+                                <span data-i18n="layers.custom-layer-url-helptext-normal"
+                                    >URL for normal layers, ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png</span
+                                ><br />
+                                <span data-i18n="layers.custom-layer-url-helptext-overpass"
+                                    >Overpass Query, ex: nwr[shop]['diet:vegan']['diet:vegan'!=no];</span
+                                >
+                            </p>
+                        </div>
 
                         <button
                             type="button"

--- a/index.html
+++ b/index.html
@@ -847,7 +847,10 @@
 
             <div class="leaflet-sidebar-flex-row flexgrow">
                 <div id="map" class="leaflet-sidebar-map">
-                    <div id="message"></div>
+                    <div id="notification_jar">
+                        <div id="message"></div>
+                        <div id="overpass_loading_indicator"></div>
+                    </div>
                     <div id="preview" hidden data-i18n="map.preview">Preview</div>
                 </div>
 

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -1,4 +1,7 @@
 BR.LayersConfig = L.Class.extend({
+    overpassFrontend: new OverpassFrontend(
+        (BR.conf.overpassBaseUrl || '//overpass-api.de/api/interpreter').replace('?data=', '')
+    ),
     defaultBaseLayers: BR.confLayers.defaultBaseLayers,
     defaultOverlays: BR.confLayers.defaultOverlays,
     legacyNameToIdMap: BR.confLayers.legacyNameToIdMap,
@@ -251,6 +254,19 @@ BR.LayersConfig = L.Class.extend({
             if (props.subdomains) {
                 layer.subdomains = props.subdomains;
             }
+        } else if (props.dataSource === 'OverpassAPI') {
+            layer = new OverpassLayer({
+                overpassFrontend: this.overpassFrontend,
+                query: props.query,
+                minZoom: undefined,
+                feature: {
+                    title: '{{ tags.name }}',
+                    body:
+                        '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{{ v }}</td></tr>{% endif %}{% endfor %}</table>',
+                    markerSymbol:
+                        '<img anchorX="13" anchorY="42" width="25" height="42" signAnchorX="0" signAnchorY="-30" src="dist/images/marker-icon.png">',
+                },
+            });
         } else {
             // JOSM
             var josmUrl = url;

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -176,7 +176,7 @@ BR.LayersConfig = L.Class.extend({
         return new OverpassLayer({
             overpassFrontend: this.overpassFrontend,
             query: query,
-            minZoom: undefined,
+            minZoom: 12,
             feature: {
                 title: '{{ tags.name }}',
                 body:

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -262,7 +262,7 @@ BR.LayersConfig = L.Class.extend({
                 feature: {
                     title: '{{ tags.name }}',
                     body:
-                        '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{{ v }}</td></tr>{% endif %}{% endfor %}</table>',
+                        '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
                     markerSymbol:
                         '<img anchorX="13" anchorY="42" width="25" height="42" signAnchorX="0" signAnchorY="-30" src="dist/images/marker-icon.png">',
                 },

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -172,6 +172,21 @@ BR.LayersConfig = L.Class.extend({
         return result;
     },
 
+    createOverpassLayer: function (query) {
+        return new OverpassLayer({
+            overpassFrontend: this.overpassFrontend,
+            query: query,
+            minZoom: undefined,
+            feature: {
+                title: '{{ tags.name }}',
+                body:
+                    '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
+                markerSymbol:
+                    '<img anchorX="13" anchorY="42" width="25" height="42" signAnchorX="0" signAnchorY="-30" src="dist/images/marker-icon.png">',
+            },
+        });
+    },
+
     createLayer: function (layerData) {
         var props = layerData.properties;
         var url = props.url;
@@ -255,18 +270,7 @@ BR.LayersConfig = L.Class.extend({
                 layer.subdomains = props.subdomains;
             }
         } else if (props.dataSource === 'OverpassAPI') {
-            layer = new OverpassLayer({
-                overpassFrontend: this.overpassFrontend,
-                query: props.query,
-                minZoom: undefined,
-                feature: {
-                    title: '{{ tags.name }}',
-                    body:
-                        '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
-                    markerSymbol:
-                        '<img anchorX="13" anchorY="42" width="25" height="42" signAnchorX="0" signAnchorY="-30" src="dist/images/marker-icon.png">',
-                },
-            });
+            layer = this.createOverpassLayer(props.query);
         } else {
             // JOSM
             var josmUrl = url;

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -181,8 +181,7 @@ BR.LayersConfig = L.Class.extend({
                 title: '{{ tags.name }}',
                 body:
                     '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
-                markerSymbol:
-                    '<svg width="25px" height="41px" anchorX="12" anchorY="41" viewBox="0 0 32 52" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M16,1 C7.7146,1 1,7.65636364 1,15.8648485 C1,24.0760606 16,51 16,51 C16,51 31,24.0760606 31,15.8648485 C31,7.65636364 24.2815,1 16,1 L16,1 Z" fill="#436978"></path></svg><i class="fa fa-search icon-white" style="width: 25px;"></i>',
+                markerSymbol: null,
             },
         });
     },

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -182,7 +182,7 @@ BR.LayersConfig = L.Class.extend({
                 body:
                     '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
                 markerSymbol:
-                    '<img anchorX="13" anchorY="42" width="25" height="42" signAnchorX="0" signAnchorY="-30" src="dist/images/marker-icon.png">',
+                    '<svg width="25px" height="41px" anchorX="12" anchorY="41" viewBox="0 0 32 52" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M16,1 C7.7146,1 1,7.65636364 1,15.8648485 C1,24.0760606 16,51 16,51 C16,51 31,24.0760606 31,15.8648485 C31,7.65636364 24.2815,1 16,1 L16,1 Z" fill="#436978"></path></svg><i class="fa fa-search icon-white" style="width: 25px;"></i>',
             },
         });
     },

--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -85,8 +85,86 @@ BR.confLayers.tree = {
         ]
     },
     'overpass': {
+        'amenity': {
+            'financial': [
+                'atm',
+                'bank',
+            ],
+            'others': [
+                'bench',
+                'kneipp_water_cure',
+                'public_bath',
+                'shelter',
+                'shower',
+                'telephone',
+                'toilets',
+                'water_point',
+            ],
+            'sustenance': [
+                'bar',
+                'bbq',
+                'biergarten',
+                'cafe',
+                'drinking_water',
+                'fast_food',
+                'food_court',
+                'ice_cream',
+                'pub',
+                'restaurant',
+            ],
+            'transportation': [
+                'bicycle_parking',
+                'bicycle_rental',
+                'bicycle_repair_station',
+                'boat_rental',
+                'boat_sharing',
+                'bus_station',
+                'car_rental',
+                'car_sharing',
+                'car_wash',
+                'charging_station',
+                'ferry_terminal',
+                'fuel',
+                'grit_bin',
+                'motorcycle_parking',
+                'parking_entrance',
+                'parking',
+                'parking_space',
+                'taxi',
+                'vehicle_inspection',
+            ]
+        },
+        'shop': {
+            'food': [
+                'bakery',
+                'beverages',
+                'butcher',
+                'cheese',
+                'coffee',
+                'convenience',
+                'greengrocer',
+                'health_food',
+                'ice_cream',
+                'organic',
+            ]
+        },
         'tourism': [
-            'campsites'
+            'apartment',
+            'artwork',
+            'attraction',
+            'camp_site',
+            'caravan_site',
+            'chalet',
+            'gallery',
+            'guest_house',
+            'hostel',
+            'hotel',
+            'information',
+            'motel',
+            'museum',
+            'picnic_site',
+            'viewpoint',
+            'wilderness_hut',
         ]
     }
 };

--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -83,5 +83,10 @@ BR.confLayers.tree = {
                 ]
             }
         ]
+    },
+    'overpass': {
+        'tourism': [
+            'campsites'
+        ]
     }
 };

--- a/layers/overpass/amenity/financial/atm.geojson
+++ b/layers/overpass/amenity/financial/atm.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "ATM",
+    "id": "atm",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=atm]; node[amenity=bank][atm][atm!=no]; way[amenity=bank][atm][atm!=no];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/financial/atm.geojson
+++ b/layers/overpass/amenity/financial/atm.geojson
@@ -5,7 +5,7 @@
     "id": "atm",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=atm]; node[amenity=bank][atm][atm!=no]; way[amenity=bank][atm][atm!=no];);"
+    "query": "(nwr[amenity=atm]; nwr[amenity=bank][atm][atm!=no];);"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/financial/bank.geojson
+++ b/layers/overpass/amenity/financial/bank.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bank",
+    "id": "bank",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=bank]; way[amenity=bank];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/financial/bank.geojson
+++ b/layers/overpass/amenity/financial/bank.geojson
@@ -5,7 +5,7 @@
     "id": "bank",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=bank]; way[amenity=bank];);"
+    "query": "nwr[amenity=bank];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/bench.geojson
+++ b/layers/overpass/amenity/others/bench.geojson
@@ -5,7 +5,7 @@
     "id": "bench",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=bench];"
+    "query": "nwr[amenity=bench];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/bench.geojson
+++ b/layers/overpass/amenity/others/bench.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bench",
+    "id": "bench",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=bench];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/kneipp_water_cure.geojson
+++ b/layers/overpass/amenity/others/kneipp_water_cure.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Kneipp water cure",
+    "id": "kneipp_water_cure",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=kneipp_water_cure]; way[amenity=kneipp_water_cure];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/kneipp_water_cure.geojson
+++ b/layers/overpass/amenity/others/kneipp_water_cure.geojson
@@ -5,7 +5,7 @@
     "id": "kneipp_water_cure",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=kneipp_water_cure]; way[amenity=kneipp_water_cure];);"
+    "query": "nwr[amenity=kneipp_water_cure];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/public_bath.geojson
+++ b/layers/overpass/amenity/others/public_bath.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Public bath",
+    "id": "public_bath",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=public_bath]; way[amenity=public_bath];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/public_bath.geojson
+++ b/layers/overpass/amenity/others/public_bath.geojson
@@ -5,7 +5,7 @@
     "id": "public_bath",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=public_bath]; way[amenity=public_bath];);"
+    "query": "nwr[amenity=public_bath];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/shelter.geojson
+++ b/layers/overpass/amenity/others/shelter.geojson
@@ -5,7 +5,7 @@
     "id": "shelter",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=shelter]; way[amenity=shelter];);"
+    "query": "nwr[amenity=shelter];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/shelter.geojson
+++ b/layers/overpass/amenity/others/shelter.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Shelter",
+    "id": "shelter",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=shelter]; way[amenity=shelter];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/shower.geojson
+++ b/layers/overpass/amenity/others/shower.geojson
@@ -5,7 +5,7 @@
     "id": "shower",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=shower]; way[amenity=shower];);"
+    "query": "nwr[amenity=shower];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/shower.geojson
+++ b/layers/overpass/amenity/others/shower.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Shower",
+    "id": "shower",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=shower]; way[amenity=shower];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/telephone.geojson
+++ b/layers/overpass/amenity/others/telephone.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Telephone",
+    "id": "telephone",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=telephone];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/telephone.geojson
+++ b/layers/overpass/amenity/others/telephone.geojson
@@ -5,7 +5,7 @@
     "id": "telephone",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=telephone];"
+    "query": "nwr[amenity=telephone];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/toilets.geojson
+++ b/layers/overpass/amenity/others/toilets.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Toilets",
+    "id": "toilets",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=toilets]; way[amenity=toilets];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/others/toilets.geojson
+++ b/layers/overpass/amenity/others/toilets.geojson
@@ -5,7 +5,7 @@
     "id": "toilets",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=toilets]; way[amenity=toilets];);"
+    "query": "nwr[amenity=toilets];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/water_point.geojson
+++ b/layers/overpass/amenity/others/water_point.geojson
@@ -5,7 +5,7 @@
     "id": "water_point",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=water_point];"
+    "query": "nwr[amenity=water_point];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/others/water_point.geojson
+++ b/layers/overpass/amenity/others/water_point.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Water point",
+    "id": "water_point",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=water_point];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/bar.geojson
+++ b/layers/overpass/amenity/sustenance/bar.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bar",
+    "id": "bar",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=bar]; way[amenity=bar];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/bar.geojson
+++ b/layers/overpass/amenity/sustenance/bar.geojson
@@ -5,7 +5,7 @@
     "id": "bar",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=bar]; way[amenity=bar];);"
+    "query": "nwr[amenity=bar];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/bbq.geojson
+++ b/layers/overpass/amenity/sustenance/bbq.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bbq",
+    "id": "bbq",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=bbq];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/bbq.geojson
+++ b/layers/overpass/amenity/sustenance/bbq.geojson
@@ -1,11 +1,11 @@
 {
   "geometry": null,
   "properties": {
-    "name": "Bbq",
+    "name": "BBQ",
     "id": "bbq",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=bbq];"
+    "query": "nwr[amenity=bbq];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/biergarten.geojson
+++ b/layers/overpass/amenity/sustenance/biergarten.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Biergarten",
+    "id": "biergarten",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=biergarten]; way[amenity=biergarten];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/biergarten.geojson
+++ b/layers/overpass/amenity/sustenance/biergarten.geojson
@@ -5,7 +5,7 @@
     "id": "biergarten",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=biergarten]; way[amenity=biergarten];);"
+    "query": "nwr[amenity=biergarten];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/cafe.geojson
+++ b/layers/overpass/amenity/sustenance/cafe.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Cafe",
+    "id": "cafe",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=cafe]; way[amenity=cafe];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/cafe.geojson
+++ b/layers/overpass/amenity/sustenance/cafe.geojson
@@ -5,7 +5,7 @@
     "id": "cafe",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=cafe]; way[amenity=cafe];);"
+    "query": "nwr[amenity=cafe];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/drinking_water.geojson
+++ b/layers/overpass/amenity/sustenance/drinking_water.geojson
@@ -1,11 +1,11 @@
 {
   "geometry": null,
   "properties": {
-    "name": "Campsites",
-    "id": "campsites",
+    "name": "Drinking water",
+    "id": "drinking_water",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=camp_site];way[tourism=camp_site];);"
+    "query": "node[amenity=drinking_water];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/drinking_water.geojson
+++ b/layers/overpass/amenity/sustenance/drinking_water.geojson
@@ -5,7 +5,7 @@
     "id": "drinking_water",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=drinking_water];"
+    "query": "nwr[amenity=drinking_water];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/fast_food.geojson
+++ b/layers/overpass/amenity/sustenance/fast_food.geojson
@@ -5,7 +5,7 @@
     "id": "fast_food",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=fast_food]; way[amenity=fast_food];);"
+    "query": "nwr[amenity=fast_food];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/fast_food.geojson
+++ b/layers/overpass/amenity/sustenance/fast_food.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Fast food",
+    "id": "fast_food",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=fast_food]; way[amenity=fast_food];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/food_court.geojson
+++ b/layers/overpass/amenity/sustenance/food_court.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Food court",
+    "id": "food_court",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=food_court]; way[amenity=food_court];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/food_court.geojson
+++ b/layers/overpass/amenity/sustenance/food_court.geojson
@@ -5,7 +5,7 @@
     "id": "food_court",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=food_court]; way[amenity=food_court];);"
+    "query": "nwr[amenity=food_court];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/ice_cream.geojson
+++ b/layers/overpass/amenity/sustenance/ice_cream.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Ice cream",
+    "id": "ice_cream",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=ice_cream]; way[amenity=ice_cream];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/ice_cream.geojson
+++ b/layers/overpass/amenity/sustenance/ice_cream.geojson
@@ -5,7 +5,7 @@
     "id": "ice_cream",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=ice_cream]; way[amenity=ice_cream];);"
+    "query": "nwr[amenity=ice_cream];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/pub.geojson
+++ b/layers/overpass/amenity/sustenance/pub.geojson
@@ -5,7 +5,7 @@
     "id": "pub",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=pub]; way[amenity=pub];);"
+    "query": "nwr[amenity=pub];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/pub.geojson
+++ b/layers/overpass/amenity/sustenance/pub.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Pub",
+    "id": "pub",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=pub]; way[amenity=pub];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/sustenance/restaurant.geojson
+++ b/layers/overpass/amenity/sustenance/restaurant.geojson
@@ -5,7 +5,7 @@
     "id": "restaurant",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=restaurant]; way[amenity=restaurant];);"
+    "query": "nwr[amenity=restaurant];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/sustenance/restaurant.geojson
+++ b/layers/overpass/amenity/sustenance/restaurant.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Restaurant",
+    "id": "restaurant",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=restaurant]; way[amenity=restaurant];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/bicycle_parking.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_parking.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bicycle parking",
+    "id": "bicycle_parking",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=bicycle_parking]; way[amenity=bicycle_parking];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/bicycle_parking.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_parking.geojson
@@ -5,7 +5,7 @@
     "id": "bicycle_parking",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=bicycle_parking]; way[amenity=bicycle_parking];);"
+    "query": "nwr[amenity=bicycle_parking];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/bicycle_rental.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_rental.geojson
@@ -5,7 +5,7 @@
     "id": "bicycle_rental",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=bicycle_rental]; way[amenity=bicycle_rental];);"
+    "query": "nwr[amenity=bicycle_rental];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/bicycle_rental.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_rental.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bicycle rental",
+    "id": "bicycle_rental",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=bicycle_rental]; way[amenity=bicycle_rental];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/bicycle_repair_station.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_repair_station.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bicycle repair station",
+    "id": "bicycle_repair_station",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=bicycle_repair_station]; way[amenity=bicycle_repair_station];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/bicycle_repair_station.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_repair_station.geojson
@@ -5,7 +5,7 @@
     "id": "bicycle_repair_station",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=bicycle_repair_station]; way[amenity=bicycle_repair_station];);"
+    "query": "nwr[amenity=bicycle_repair_station];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/boat_rental.geojson
+++ b/layers/overpass/amenity/transportation/boat_rental.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Boat rental",
+    "id": "boat_rental",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=boat_rental]; way[amenity=boat_rental];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/boat_rental.geojson
+++ b/layers/overpass/amenity/transportation/boat_rental.geojson
@@ -5,7 +5,7 @@
     "id": "boat_rental",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=boat_rental]; way[amenity=boat_rental];);"
+    "query": "nwr[amenity=boat_rental];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/boat_sharing.geojson
+++ b/layers/overpass/amenity/transportation/boat_sharing.geojson
@@ -5,7 +5,7 @@
     "id": "boat_sharing",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=boat_sharing]; way[amenity=boat_sharing];);"
+    "query": "nwr[amenity=boat_sharing];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/boat_sharing.geojson
+++ b/layers/overpass/amenity/transportation/boat_sharing.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Boat sharing",
+    "id": "boat_sharing",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=boat_sharing]; way[amenity=boat_sharing];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/bus_station.geojson
+++ b/layers/overpass/amenity/transportation/bus_station.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bus station",
+    "id": "bus_station",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=bus_station]; way[amenity=bus_station];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/bus_station.geojson
+++ b/layers/overpass/amenity/transportation/bus_station.geojson
@@ -5,7 +5,7 @@
     "id": "bus_station",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=bus_station]; way[amenity=bus_station];);"
+    "query": "nwr[amenity=bus_station];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/car_rental.geojson
+++ b/layers/overpass/amenity/transportation/car_rental.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Car rental",
+    "id": "car_rental",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=car_rental]; way[amenity=car_rental];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/car_rental.geojson
+++ b/layers/overpass/amenity/transportation/car_rental.geojson
@@ -5,7 +5,7 @@
     "id": "car_rental",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=car_rental]; way[amenity=car_rental];);"
+    "query": "nwr[amenity=car_rental];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/car_sharing.geojson
+++ b/layers/overpass/amenity/transportation/car_sharing.geojson
@@ -5,7 +5,7 @@
     "id": "car_sharing",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=car_sharing]; way[amenity=car_sharing];);"
+    "query": "nwr[amenity=car_sharing];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/car_sharing.geojson
+++ b/layers/overpass/amenity/transportation/car_sharing.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Car sharing",
+    "id": "car_sharing",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=car_sharing]; way[amenity=car_sharing];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/car_wash.geojson
+++ b/layers/overpass/amenity/transportation/car_wash.geojson
@@ -5,7 +5,7 @@
     "id": "car_wash",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=car_wash]; way[amenity=car_wash];);"
+    "query": "nwr[amenity=car_wash];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/car_wash.geojson
+++ b/layers/overpass/amenity/transportation/car_wash.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Car wash",
+    "id": "car_wash",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=car_wash]; way[amenity=car_wash];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/charging_station.geojson
+++ b/layers/overpass/amenity/transportation/charging_station.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Charging station",
+    "id": "charging_station",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=charging_station];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/charging_station.geojson
+++ b/layers/overpass/amenity/transportation/charging_station.geojson
@@ -5,7 +5,7 @@
     "id": "charging_station",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=charging_station];"
+    "query": "nwr[amenity=charging_station];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/ferry_terminal.geojson
+++ b/layers/overpass/amenity/transportation/ferry_terminal.geojson
@@ -5,7 +5,7 @@
     "id": "ferry_terminal",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=ferry_terminal]; way[amenity=ferry_terminal];);"
+    "query": "nwr[amenity=ferry_terminal];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/ferry_terminal.geojson
+++ b/layers/overpass/amenity/transportation/ferry_terminal.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Ferry terminal",
+    "id": "ferry_terminal",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=ferry_terminal]; way[amenity=ferry_terminal];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/fuel.geojson
+++ b/layers/overpass/amenity/transportation/fuel.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Fuel",
+    "id": "fuel",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=fuel]; way[amenity=fuel];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/fuel.geojson
+++ b/layers/overpass/amenity/transportation/fuel.geojson
@@ -5,7 +5,7 @@
     "id": "fuel",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=fuel]; way[amenity=fuel];);"
+    "query": "nwr[amenity=fuel];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/grit_bin.geojson
+++ b/layers/overpass/amenity/transportation/grit_bin.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Grit bin",
+    "id": "grit_bin",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=grit_bin];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/grit_bin.geojson
+++ b/layers/overpass/amenity/transportation/grit_bin.geojson
@@ -5,7 +5,7 @@
     "id": "grit_bin",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=grit_bin];"
+    "query": "nwr[amenity=grit_bin];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/motorcycle_parking.geojson
+++ b/layers/overpass/amenity/transportation/motorcycle_parking.geojson
@@ -5,7 +5,7 @@
     "id": "motorcycle_parking",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=motorcycle_parking]; way[amenity=motorcycle_parking];);"
+    "query": "nwr[amenity=motorcycle_parking];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/motorcycle_parking.geojson
+++ b/layers/overpass/amenity/transportation/motorcycle_parking.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Motorcycle parking",
+    "id": "motorcycle_parking",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=motorcycle_parking]; way[amenity=motorcycle_parking];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/parking.geojson
+++ b/layers/overpass/amenity/transportation/parking.geojson
@@ -5,7 +5,7 @@
     "id": "parking",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=parking]; way[amenity=parking];);"
+    "query": "nwr[amenity=parking];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/parking.geojson
+++ b/layers/overpass/amenity/transportation/parking.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Parking",
+    "id": "parking",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=parking]; way[amenity=parking];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/parking_entrance.geojson
+++ b/layers/overpass/amenity/transportation/parking_entrance.geojson
@@ -5,7 +5,7 @@
     "id": "parking_entrance",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[amenity=parking_entrance];"
+    "query": "nwr[amenity=parking_entrance];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/parking_entrance.geojson
+++ b/layers/overpass/amenity/transportation/parking_entrance.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Parking entrance",
+    "id": "parking_entrance",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[amenity=parking_entrance];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/parking_space.geojson
+++ b/layers/overpass/amenity/transportation/parking_space.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Parking space",
+    "id": "parking_space",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=parking_space]; way[amenity=parking_space];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/parking_space.geojson
+++ b/layers/overpass/amenity/transportation/parking_space.geojson
@@ -5,7 +5,7 @@
     "id": "parking_space",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=parking_space]; way[amenity=parking_space];);"
+    "query": "nwr[amenity=parking_space];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/taxi.geojson
+++ b/layers/overpass/amenity/transportation/taxi.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Taxi",
+    "id": "taxi",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=taxi]; way[amenity=taxi];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/taxi.geojson
+++ b/layers/overpass/amenity/transportation/taxi.geojson
@@ -5,7 +5,7 @@
     "id": "taxi",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=taxi]; way[amenity=taxi];);"
+    "query": "nwr[amenity=taxi];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/amenity/transportation/vehicle_inspection.geojson
+++ b/layers/overpass/amenity/transportation/vehicle_inspection.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Vehicle inspection",
+    "id": "vehicle_inspection",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[amenity=vehicle_inspection]; way[amenity=vehicle_inspection];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/amenity/transportation/vehicle_inspection.geojson
+++ b/layers/overpass/amenity/transportation/vehicle_inspection.geojson
@@ -5,7 +5,7 @@
     "id": "vehicle_inspection",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[amenity=vehicle_inspection]; way[amenity=vehicle_inspection];);"
+    "query": "nwr[amenity=vehicle_inspection];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/bakery.geojson
+++ b/layers/overpass/shop/food/bakery.geojson
@@ -5,7 +5,7 @@
     "id": "bakery",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=bakery]; way[shop=bakery];);"
+    "query": "nwr[shop=bakery];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/bakery.geojson
+++ b/layers/overpass/shop/food/bakery.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Bakery",
+    "id": "bakery",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=bakery]; way[shop=bakery];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/beverages.geojson
+++ b/layers/overpass/shop/food/beverages.geojson
@@ -5,7 +5,7 @@
     "id": "beverages",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=beverages]; way[shop=beverages];);"
+    "query": "nwr[shop=beverages];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/beverages.geojson
+++ b/layers/overpass/shop/food/beverages.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Beverages",
+    "id": "beverages",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=beverages]; way[shop=beverages];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/butcher.geojson
+++ b/layers/overpass/shop/food/butcher.geojson
@@ -5,7 +5,7 @@
     "id": "butcher",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=butcher]; way[shop=butcher];);"
+    "query": "nwr[shop=butcher];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/butcher.geojson
+++ b/layers/overpass/shop/food/butcher.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Butcher",
+    "id": "butcher",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=butcher]; way[shop=butcher];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/cheese.geojson
+++ b/layers/overpass/shop/food/cheese.geojson
@@ -5,7 +5,7 @@
     "id": "cheese",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=cheese]; way[shop=cheese];);"
+    "query": "nwr[shop=cheese];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/cheese.geojson
+++ b/layers/overpass/shop/food/cheese.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Cheese",
+    "id": "cheese",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=cheese]; way[shop=cheese];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/coffee.geojson
+++ b/layers/overpass/shop/food/coffee.geojson
@@ -5,7 +5,7 @@
     "id": "coffee",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=coffee]; way[shop=coffee];);"
+    "query": "nwr[shop=coffee];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/coffee.geojson
+++ b/layers/overpass/shop/food/coffee.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Coffee",
+    "id": "coffee",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=coffee]; way[shop=coffee];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/convenience.geojson
+++ b/layers/overpass/shop/food/convenience.geojson
@@ -5,7 +5,7 @@
     "id": "convenience",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=convenience]; way[shop=convenience];);"
+    "query": "nwr[shop=convenience];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/convenience.geojson
+++ b/layers/overpass/shop/food/convenience.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Convenience",
+    "id": "convenience",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=convenience]; way[shop=convenience];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/greengrocer.geojson
+++ b/layers/overpass/shop/food/greengrocer.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Greengrocer",
+    "id": "greengrocer",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=greengrocer]; way[shop=greengrocer];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/greengrocer.geojson
+++ b/layers/overpass/shop/food/greengrocer.geojson
@@ -5,7 +5,7 @@
     "id": "greengrocer",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=greengrocer]; way[shop=greengrocer];);"
+    "query": "nwr[shop=greengrocer];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/health_food.geojson
+++ b/layers/overpass/shop/food/health_food.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Health food",
+    "id": "health_food",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=health_food]; way[shop=health_food];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/health_food.geojson
+++ b/layers/overpass/shop/food/health_food.geojson
@@ -5,7 +5,7 @@
     "id": "health_food",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=health_food]; way[shop=health_food];);"
+    "query": "nwr[shop=health_food];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/ice_cream.geojson
+++ b/layers/overpass/shop/food/ice_cream.geojson
@@ -5,7 +5,7 @@
     "id": "ice_cream",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop=ice_cream]; way[shop=ice_cream];);"
+    "query": "nwr[shop=ice_cream];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/shop/food/ice_cream.geojson
+++ b/layers/overpass/shop/food/ice_cream.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Ice cream",
+    "id": "ice_cream",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop=ice_cream]; way[shop=ice_cream];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/organic.geojson
+++ b/layers/overpass/shop/food/organic.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Organic",
+    "id": "organic",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[shop~'supermarket|convenience'][organic][organic!=no]; way[shop~'supermarket|convenience'][organic][organic!=no];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/shop/food/organic.geojson
+++ b/layers/overpass/shop/food/organic.geojson
@@ -5,7 +5,7 @@
     "id": "organic",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[shop~'supermarket|convenience'][organic][organic!=no]; way[shop~'supermarket|convenience'][organic][organic!=no];);"
+    "query": "nwr[shop~'supermarket|convenience'][organic][organic!=no];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/apartment.geojson
+++ b/layers/overpass/tourism/apartment.geojson
@@ -5,7 +5,7 @@
     "id": "apartment",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=apartment]; way[tourism=apartment];);"
+    "query": "nwr[tourism=apartment];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/apartment.geojson
+++ b/layers/overpass/tourism/apartment.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Apartment",
+    "id": "apartment",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=apartment]; way[tourism=apartment];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/artwork.geojson
+++ b/layers/overpass/tourism/artwork.geojson
@@ -5,7 +5,7 @@
     "id": "artwork",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=artwork]; way[tourism=artwork];);"
+    "query": "nwr[tourism=artwork];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/artwork.geojson
+++ b/layers/overpass/tourism/artwork.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Artwork",
+    "id": "artwork",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=artwork]; way[tourism=artwork];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/attraction.geojson
+++ b/layers/overpass/tourism/attraction.geojson
@@ -5,7 +5,7 @@
     "id": "attraction",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=attraction]; way[tourism=attraction];);"
+    "query": "nwr[tourism=attraction];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/attraction.geojson
+++ b/layers/overpass/tourism/attraction.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Attraction",
+    "id": "attraction",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=attraction]; way[tourism=attraction];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/camp_site.geojson
+++ b/layers/overpass/tourism/camp_site.geojson
@@ -5,7 +5,7 @@
     "id": "camp_site",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=camp_site]; way[tourism=camp_site];);"
+    "query": "nwr[tourism=camp_site];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/camp_site.geojson
+++ b/layers/overpass/tourism/camp_site.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Camp site",
+    "id": "camp_site",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=camp_site]; way[tourism=camp_site];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/campsites.geojson
+++ b/layers/overpass/tourism/campsites.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Campsites",
+    "id": "campsites",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=camp_site];way[tourism=camp_site];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/caravan_site.geojson
+++ b/layers/overpass/tourism/caravan_site.geojson
@@ -5,7 +5,7 @@
     "id": "caravan_site",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=caravan_site]; way[tourism=caravan_site];);"
+    "query": "nwr[tourism=caravan_site];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/caravan_site.geojson
+++ b/layers/overpass/tourism/caravan_site.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Caravan site",
+    "id": "caravan_site",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=caravan_site]; way[tourism=caravan_site];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/chalet.geojson
+++ b/layers/overpass/tourism/chalet.geojson
@@ -5,7 +5,7 @@
     "id": "chalet",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=chalet]; way[tourism=chalet];);"
+    "query": "nwr[tourism=chalet];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/chalet.geojson
+++ b/layers/overpass/tourism/chalet.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Chalet",
+    "id": "chalet",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=chalet]; way[tourism=chalet];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/gallery.geojson
+++ b/layers/overpass/tourism/gallery.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Gallery",
+    "id": "gallery",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=gallery]; way[tourism=gallery];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/gallery.geojson
+++ b/layers/overpass/tourism/gallery.geojson
@@ -5,7 +5,7 @@
     "id": "gallery",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=gallery]; way[tourism=gallery];);"
+    "query": "nwr[tourism=gallery];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/guest_house.geojson
+++ b/layers/overpass/tourism/guest_house.geojson
@@ -5,7 +5,7 @@
     "id": "guest_house",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=guest_house]; way[tourism=guest_house];);"
+    "query": "nwr[tourism=guest_house];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/guest_house.geojson
+++ b/layers/overpass/tourism/guest_house.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Guest house",
+    "id": "guest_house",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=guest_house]; way[tourism=guest_house];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/hostel.geojson
+++ b/layers/overpass/tourism/hostel.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Hostel",
+    "id": "hostel",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=hostel]; way[tourism=hostel];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/hostel.geojson
+++ b/layers/overpass/tourism/hostel.geojson
@@ -5,7 +5,7 @@
     "id": "hostel",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=hostel]; way[tourism=hostel];);"
+    "query": "nwr[tourism=hostel];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/hotel.geojson
+++ b/layers/overpass/tourism/hotel.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Hotel",
+    "id": "hotel",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=hotel]; way[tourism=hotel];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/hotel.geojson
+++ b/layers/overpass/tourism/hotel.geojson
@@ -5,7 +5,7 @@
     "id": "hotel",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=hotel]; way[tourism=hotel];);"
+    "query": "nwr[tourism=hotel];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/information.geojson
+++ b/layers/overpass/tourism/information.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Information",
+    "id": "information",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=information]; way[tourism=information];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/information.geojson
+++ b/layers/overpass/tourism/information.geojson
@@ -5,7 +5,7 @@
     "id": "information",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=information]; way[tourism=information];);"
+    "query": "nwr[tourism=information];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/motel.geojson
+++ b/layers/overpass/tourism/motel.geojson
@@ -5,7 +5,7 @@
     "id": "motel",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=motel]; way[tourism=motel];);"
+    "query": "nwr[tourism=motel];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/motel.geojson
+++ b/layers/overpass/tourism/motel.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Motel",
+    "id": "motel",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=motel]; way[tourism=motel];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/museum.geojson
+++ b/layers/overpass/tourism/museum.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Museum",
+    "id": "museum",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=museum]; way[tourism=museum];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/museum.geojson
+++ b/layers/overpass/tourism/museum.geojson
@@ -5,7 +5,7 @@
     "id": "museum",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=museum]; way[tourism=museum];);"
+    "query": "nwr[tourism=museum];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/picnic_site.geojson
+++ b/layers/overpass/tourism/picnic_site.geojson
@@ -5,7 +5,7 @@
     "id": "picnic_site",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=picnic_site]; way[tourism=picnic_site];);"
+    "query": "nwr[tourism=picnic_site];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/picnic_site.geojson
+++ b/layers/overpass/tourism/picnic_site.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Picnic site",
+    "id": "picnic_site",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=picnic_site]; way[tourism=picnic_site];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/viewpoint.geojson
+++ b/layers/overpass/tourism/viewpoint.geojson
@@ -5,7 +5,7 @@
     "id": "viewpoint",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "node[tourism=viewpoint];"
+    "query": "nwr[tourism=viewpoint];"
   },
   "type": "Feature"
 }

--- a/layers/overpass/tourism/viewpoint.geojson
+++ b/layers/overpass/tourism/viewpoint.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Viewpoint",
+    "id": "viewpoint",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "node[tourism=viewpoint];"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/wilderness_hut.geojson
+++ b/layers/overpass/tourism/wilderness_hut.geojson
@@ -1,0 +1,11 @@
+{
+  "geometry": null,
+  "properties": {
+    "name": "Wilderness hut",
+    "id": "wilderness_hut",
+    "overlay": true,
+    "dataSource": "OverpassAPI",
+    "query": "(node[tourism=wilderness_hut]; way[tourism=wilderness_hut];);"
+  },
+  "type": "Feature"
+}

--- a/layers/overpass/tourism/wilderness_hut.geojson
+++ b/layers/overpass/tourism/wilderness_hut.geojson
@@ -5,7 +5,7 @@
     "id": "wilderness_hut",
     "overlay": true,
     "dataSource": "OverpassAPI",
-    "query": "(node[tourism=wilderness_hut]; way[tourism=wilderness_hut];);"
+    "query": "nwr[tourism=wilderness_hut];"
   },
   "type": "Feature"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -78,6 +78,7 @@
     "custom-layer-url-label": "Custom layer URL/Query",
     "customize": "Customize layers",
     "opacity-slider": "Opacity slider",
+    "overpass-loading-indicator": "Running Overpass API query ...",
     "remove-selection": "Remove selection"
   },
   "loadNogos": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -71,10 +71,13 @@
     "add-base": "Add base layer",
     "add-overlay": "Add overlay",
     "add-overpass": "Add overpass query",
+    "custom-layer-name-helptext": "ex: OpenStreetMap",
+    "custom-layer-name-label": "Custom layer name",
+    "custom-layer-url-helptext-normal": "URL for normal layers, ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "custom-layer-url-helptext-overpass": "Overpass Query, ex: nwr[shop]['diet:vegan']['diet:vegan'!=no];",
+    "custom-layer-url-label": "Custom layer URL/Query",
     "customize": "Customize layers",
     "opacity-slider": "Opacity slider",
-    "placeholder-layer-name": "Custom layer name. (ex: OpenStreetMap)",
-    "placeholder-layer-url": "Custom layer URL. (ex: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png)",
     "remove-selection": "Remove selection"
   },
   "loadNogos": {
@@ -244,7 +247,7 @@
       "overlay-opacity": "Overlay transparency",
       "overlay-opacity_plural": "Overlays transparency",
       "table": {
-        "URL": "URL",
+        "URL": "URL/Query",
         "empty": "No custom layer configured yet.",
         "name": "Name",
         "type": "Type",

--- a/locales/en.json
+++ b/locales/en.json
@@ -70,6 +70,7 @@
   "layers": {
     "add-base": "Add base layer",
     "add-overlay": "Add overlay",
+    "add-overpass": "Add overpass query",
     "customize": "Customize layers",
     "opacity-slider": "Opacity slider",
     "placeholder-layer-name": "Custom layer name. (ex: OpenStreetMap)",
@@ -248,7 +249,8 @@
         "name": "Name",
         "type": "Type",
         "type_layer": "Layer",
-        "type_overlay": "Overlay"
+        "type_overlay": "Overlay",
+        "type_overpass_query": "Overpass Query"
       },
       "title": "Layers",
       "tooltip": "Select layers"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "leaflet.stravasegments": "2.3.2",
         "mapbbcode": "MapBBCode/mapbbcode#v1.2.0",
         "osmtogeojson": "^3.0.0-beta.4",
+        "overpass-layer": "^3.0.0",
         "regenerator-runtime": "^0.13.7",
         "togpx": "^0.5.4",
         "topojson-client": "^3.1.0",
@@ -276,6 +277,11 @@
         "core-js-bundle": {
             "main": [
                 "minified.js"
+            ]
+        },
+        "overpass-layer": {
+            "main": [
+                "dist/overpass-layer.js"
             ]
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,6 +944,17 @@
     readdirp "^2.2.1"
     upath "^1.1.1"
 
+"@turf/along@^6.0.1":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/along/-/along-6.3.0.tgz#9a1d2d418027945f113e15029f53069b335bf426"
+  integrity sha512-2j0nHp38IuzESyv5/9hLYM2MuUe155Kw390lkQtiLjhRtTeYQNEaRy+uhZhf3/DWrjGULH1HatLc5j0CmiwrJA==
+  dependencies:
+    "@turf/bearing" "^6.3.0"
+    "@turf/destination" "^6.3.0"
+    "@turf/distance" "^6.3.0"
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
 "@turf/along@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/along/-/along-6.2.0.tgz#509438f1b83cd01b7edbb3b9830b46137e554ca0"
@@ -973,6 +984,14 @@
     "@turf/helpers" "^6.2.0"
     "@turf/meta" "^6.2.0"
 
+"@turf/bbox-clip@^6.0.3":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-clip/-/bbox-clip-6.3.0.tgz#43bed0d963d06e254135c27e4bc13ed55ad89cf9"
+  integrity sha512-DCFs1MdX3P7SzZiBjT1kWBp4g0cfv8Yn2/Ccq3JP4iVaqNQJujPfe0WwZjjTdXLbLLFTjoxnCJBjy3WZDmLvlw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
 "@turf/bbox-clip@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/bbox-clip/-/bbox-clip-6.2.0.tgz#0bb64bd1a0fe5852c098c1346919dcb790d011ad"
@@ -996,6 +1015,14 @@
     "@turf/helpers" "^6.2.0"
     "@turf/meta" "^6.2.0"
 
+"@turf/bbox@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-5.1.5.tgz#3051df514ad4c50f4a4f9b8a2d15fd8b6840eda3"
+  integrity sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+
 "@turf/bearing@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.2.0.tgz#bdd02f5502f2e8cb4207be872494941b72b277b8"
@@ -1003,6 +1030,14 @@
   dependencies:
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
+
+"@turf/bearing@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.3.0.tgz#4de3f398382772031e84491734902b8d37bc8c84"
+  integrity sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
 
 "@turf/bezier-spline@^6.2.0":
   version "6.2.0"
@@ -1094,6 +1129,22 @@
     "@turf/line-segment" "^6.2.0"
     "@turf/rhumb-bearing" "^6.2.0"
 
+"@turf/boolean-point-in-polygon@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz#f01cc194d1e030a548bfda981cba43cfd62941b7"
+  integrity sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
+"@turf/boolean-point-in-polygon@^6.0.1":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.3.0.tgz#784952a36c64119e90fbe94650245da62ecd8fc2"
+  integrity sha512-NqFSsoE6OwhDK19IllDQRhEQEkF7UVEOlqH9vgS1fGg4T6NcyKvACJs05c9457tL7QSbV9ZS53f2qiLneFL+qg==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
 "@turf/boolean-point-in-polygon@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.2.0.tgz#b9f4984535a4d0cb98959ff6e402b82df14f3015"
@@ -1165,6 +1216,14 @@
     "@turf/invariant" "^6.2.0"
     "@turf/meta" "^6.2.0"
 
+"@turf/center@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/center/-/center-5.1.5.tgz#44ab2cd954f63c0d37757f7158a99c3ef5114b80"
+  integrity sha1-RKss2VT2PA03dX9xWKmcPvURS4A=
+  dependencies:
+    "@turf/bbox" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+
 "@turf/center@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/center/-/center-6.2.0.tgz#ace81665eeb019b676b0fdf5e7d95a734b946e11"
@@ -1196,6 +1255,13 @@
   dependencies:
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
+
+"@turf/clone@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-5.1.5.tgz#253e8d35477181976e33adfab50a0f02a7f0e367"
+  integrity sha1-JT6NNUdxgZduM636tQoPAqfw42c=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
 
 "@turf/clone@^6.2.0":
   version "6.2.0"
@@ -1282,6 +1348,23 @@
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
 
+"@turf/destination@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.3.0.tgz#7032eeb0ec5d1a035d98faaddac039eea96abb04"
+  integrity sha512-aLt3U/XkJWyZW08Ln1qZwBNAGh27yhmYLu892+dBj3gKP6UUiR6ZopXxrBwjBVe00A6k2ktftKDn79qe0hptuw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/difference@^6.0.2":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.3.0.tgz#dee2bb10fb80896ba3a7c8fe30be3e9f9d604c1e"
+  integrity sha512-f4P0ra0jBOFk4HO8n/9FZ3NEmOX7FHCXHy/4Z1RSUUQsUQDCkx6/cyqbi8BCy2ZSDUSCGHV+iPgs4fRphMzCHQ==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    polygon-clipping "^0.15.2"
+
 "@turf/difference@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.2.0.tgz#dea4c4b7f478ee907befa2ce089e64734e7c3304"
@@ -1316,6 +1399,14 @@
     "@turf/invariant" "^6.2.0"
     "@turf/meta" "^6.2.0"
 
+"@turf/distance@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-5.1.5.tgz#39cf18204bbf87587d707e609a60118909156409"
+  integrity sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
 "@turf/distance@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.2.0.tgz#a665b34944c17f349bc6ee6932c83daa3757067b"
@@ -1323,6 +1414,14 @@
   dependencies:
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
+
+"@turf/distance@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.3.0.tgz#4bd084af7fe369e921476e52b597a638dae4ed95"
+  integrity sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
 
 "@turf/ellipse@^6.2.0":
   version "6.2.0"
@@ -1342,6 +1441,14 @@
     "@turf/bbox" "^6.2.0"
     "@turf/bbox-polygon" "^6.2.0"
     "@turf/helpers" "^6.2.0"
+
+"@turf/explode@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/explode/-/explode-5.1.5.tgz#b12b2f774004a1b48f62ba95b20a1c655a3de118"
+  integrity sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
 
 "@turf/explode@^6.2.0":
   version "6.2.0"
@@ -1381,6 +1488,16 @@
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.2.0.tgz#dc770ce3b35b230f6a661824f3f87591378e379b"
   integrity sha512-ANcZ0LFpnrza52y3um8KXgbpF1l7qmJXEqY1Bv5RovdQH+kUvMrZsb4SO3q4VH4eQqlsxDLxxXl7hkjjFbDtHg==
 
+"@turf/helpers@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
+  integrity sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=
+
+"@turf/helpers@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.3.0.tgz#87f90f806c3f8ad6385ef8d2041d3662bf3c9fb1"
+  integrity sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg==
+
 "@turf/hex-grid@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/hex-grid/-/hex-grid-6.2.0.tgz#c7fceaddc8a4bd86902d4ffa8d0c646920a55b77"
@@ -1408,6 +1525,15 @@
     "@turf/square-grid" "^6.2.0"
     "@turf/triangle-grid" "^6.2.0"
 
+"@turf/intersect@^6.1.3":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-6.3.0.tgz#b22b3e888e762ae4336e085eb6f21215d06652ea"
+  integrity sha512-1YCIkyKjuTlX7HaTjtyE7ZRxLCmcu0BYr6jqoVl7TjyF2NUiNpPm3m4X1ZrSF6MfjIt5NFSGYCdNMEPgREq19w==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    polygon-clipping "^0.15.2"
+
 "@turf/intersect@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-6.2.0.tgz#739169f2719bf6cd2206e527eee2a04532748d61"
@@ -1417,12 +1543,26 @@
     "@turf/invariant" "^6.2.0"
     polygon-clipping "^0.15.2"
 
+"@turf/invariant@^5.1.5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
+  integrity sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
 "@turf/invariant@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.2.0.tgz#91c732b7c53e95afdbea944be3316bb8afd6a118"
   integrity sha512-kyhKp3rW1tDe78xFkgq9+zC6dkBJyvEwP4HNNculIXRyN4Xoo7GJECE1wPyujQppj3Lmu63GtE6B68coEZ0Gqw==
   dependencies:
     "@turf/helpers" "^6.2.0"
+
+"@turf/invariant@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.3.0.tgz#04a22b26c5503146c03fa6198176b72bd591eadf"
+  integrity sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
 
 "@turf/isobands@^6.2.0":
   version "6.2.0"
@@ -1455,6 +1595,15 @@
   integrity sha512-iMDykdjS8/GatTjAIQa8w3SkYNK/I7ZIyN+S4WUBq9aJ4BzANcn1rDqIRrTn+a6Y7VJIg4Ki9k5pmGQkgXYjmA==
   dependencies:
     "@turf/helpers" "^6.2.0"
+
+"@turf/length@^6.0.2":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/length/-/length-6.3.0.tgz#7d6b61bf870d6f056eb34ec7a787ce49f7dbe292"
+  integrity sha512-91MHtigpV7mbrMW3xyaPVtLWQU3p487t3YHU4vdxih03p+dFI512dX/FtWbd9LNgrtBt4PM1uo1WmafGvfStKA==
+  dependencies:
+    "@turf/distance" "^6.3.0"
+    "@turf/helpers" "^6.3.0"
+    "@turf/meta" "^6.3.0"
 
 "@turf/length@^6.2.0":
   version "6.2.0"
@@ -1495,6 +1644,17 @@
     "@turf/meta" "^6.2.0"
     geojson-rbush "3.x"
 
+"@turf/line-intersect@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-6.3.0.tgz#726a50edc66bb7b5e798b052b103fb0da4d1c4f4"
+  integrity sha512-3naxR7XpkPd2vst3Mw6DFry4C9m3o0/f2n/xu5UAyxb88Ie4m2k+1eqkhzMMx/0L+E6iThWpLx7DASM6q6o9ow==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/line-segment" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+    geojson-rbush "3.x"
+
 "@turf/line-offset@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/line-offset/-/line-offset-6.2.0.tgz#ec3ee6ff39bcc73a5e0e1956f1d5b0b3ffe81b16"
@@ -1526,6 +1686,15 @@
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
     "@turf/meta" "^6.2.0"
+
+"@turf/line-segment@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-6.3.0.tgz#b37d6877ee4425ebc12698860e7d355d1bf2ba9b"
+  integrity sha512-M+aDy83V+E7jYWNaf+b+A88yhnMrJhyg/lhAj6mU6UeB2PbruXB2qgSmmVDSE2dIknOvZZuIWNzEzUI07RO2kw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/meta" "^6.3.0"
 
 "@turf/line-slice-along@^6.2.0":
   version "6.2.0"
@@ -1590,6 +1759,20 @@
   dependencies:
     "@turf/helpers" "^6.2.0"
 
+"@turf/meta@^5.1.5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
+  integrity sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
+"@turf/meta@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.3.0.tgz#f3e280ab29641f21e4f99310ce77f9c8394ae394"
+  integrity sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+
 "@turf/midpoint@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/midpoint/-/midpoint-6.2.0.tgz#1fdc6289d99f286ce667992b12b684d15a3d86b5"
@@ -1608,6 +1791,19 @@
     "@turf/distance-weight" "^6.2.0"
     "@turf/helpers" "^6.2.0"
     "@turf/meta" "^6.2.0"
+
+"@turf/nearest-point-on-line@^6.0.2":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-6.3.0.tgz#a33f14fb099c292777de136f8c96ef4a7cad8ae2"
+  integrity sha512-b4C9Md1VbGn9chMgdSj2grJD4w4t0owEWOKEBwOZfdhrcksyOedVvKB7XqOFdj/8Jitel40EKAC5LQTNu24kEQ==
+  dependencies:
+    "@turf/bearing" "^6.3.0"
+    "@turf/destination" "^6.3.0"
+    "@turf/distance" "^6.3.0"
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/line-intersect" "^6.3.0"
+    "@turf/meta" "^6.3.0"
 
 "@turf/nearest-point-on-line@^6.2.0":
   version "6.2.0"
@@ -1632,6 +1828,16 @@
     "@turf/meta" "^6.2.0"
     "@turf/point-to-line-distance" "^6.2.0"
     object-assign "*"
+
+"@turf/nearest-point@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point/-/nearest-point-5.1.5.tgz#12050de41c398443224c7978de0f6213900d34fb"
+  integrity sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=
+  dependencies:
+    "@turf/clone" "^5.1.5"
+    "@turf/distance" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
 
 "@turf/nearest-point@^6.2.0":
   version "6.2.0"
@@ -1660,6 +1866,17 @@
     "@turf/distance" "^6.2.0"
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
+
+"@turf/point-on-feature@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz#30c7f032430277c6418d96d289e45b6bfb213fe7"
+  integrity sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^5.1.5"
+    "@turf/center" "^5.1.5"
+    "@turf/explode" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/nearest-point" "^5.1.5"
 
 "@turf/point-on-feature@^6.2.0":
   version "6.2.0"
@@ -2058,6 +2275,15 @@
     "@turf/unkink-polygon" "^6.2.0"
     "@turf/voronoi" "^6.2.0"
 
+"@turf/union@^6.0.3":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.3.0.tgz#12ff74d144c30f90bc8f5b8a34fe7d78acc6563a"
+  integrity sha512-m8yh13Q5E0Y+YC10+iI/Qq0Txt7UmSIFByc7DfNVlMMGTceqLFa8xGwSVdFuB/d6MWwKuzKonQMl1PUx/Vd2Iw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    polygon-clipping "^0.15.2"
+
 "@turf/union@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.2.0.tgz#60116705d6a135be61b004010341f0b9e3c43182"
@@ -2136,6 +2362,15 @@ accepts@~1.3.4:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+accessory@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/accessory/-/accessory-1.1.0.tgz#7833e9839a32ded76d26021f36a41707a520f593"
+  integrity sha1-eDPpg5oy3tdtJgIfNqQXB6Ug9ZM=
+  dependencies:
+    ap "~0.2.0"
+    balanced-match "~0.2.0"
+    dot-parts "~1.0.0"
+
 acorn-class-fields@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz#a35122f3cc6ad2bb33b1857e79215677fcfdd720"
@@ -2186,6 +2421,11 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.0.tgz#56ae4c0f434a45fff4a125e7ea95fa9c98f67a16"
   integrity sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==
 
+acorn@^5.2.1:
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -2235,6 +2475,11 @@ ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 ansi-colors@^1.0.1:
   version "1.1.0"
@@ -2353,6 +2598,11 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+ap@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ap/-/ap-0.2.0.tgz#ae0942600b29912f0d2b14ec60c45e8f330b6110"
+  integrity sha1-rglCYAspkS8NKxTsYMRejzMLYRA=
 
 append-buffer@^1.0.2:
   version "1.0.2"
@@ -2578,6 +2828,11 @@ async@^0.9.0, async@~0.9.2:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
+async@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2660,6 +2915,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+balanced-match@~0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.2.1.tgz#7bc658b4bed61eee424ad74f75f5c3e2c4df3cc7"
+  integrity sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc=
 
 base64-arraybuffer@0.1.5:
   version "0.1.5"
@@ -2770,6 +3030,14 @@ bops@0.0.6:
     base64-js "0.0.2"
     to-utf8 "0.0.1"
 
+boundingbox@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/boundingbox/-/boundingbox-1.2.3.tgz#54ae1afb830285e4700472154cb4d64fd560d95c"
+  integrity sha512-QeTwAfHloUTYemaQ/B6/lHo7cpkZwMdTpYFFsxXD8NC3pPtjcL3nZiQ0JD4CS2DK99Oo5CyUlFfo3GvL6FoI7A==
+  dependencies:
+    geojson-bounds "^1.0.2"
+    haversine "^1.1.1"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2859,6 +3127,31 @@ browser-sync@^2.26.14:
     ua-parser-js "^0.7.18"
     yargs "^15.4.1"
 
+browserify-css@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/browserify-css/-/browserify-css-0.15.0.tgz#ac9584c84b231e3a1718dd2d7718f0fcf1510b76"
+  integrity sha512-ZgLHyZ16PH6P25JlBE+5xNtdobpkc5Egh+ctc8ha3GDtuZqSSQu0ovOxOQvXt0xAmaXixth/DY9iT56HlDOxyg==
+  dependencies:
+    clean-css "^4.1.5"
+    concat-stream "^1.6.0"
+    css "^2.2.1"
+    find-node-modules "^2.0.0"
+    lodash "^4.17.11"
+    mime "^1.3.6"
+    strip-css-comments "^3.0.0"
+    through2 "2.0.x"
+
+browserify-shim@^3.8.14:
+  version "3.8.14"
+  resolved "https://registry.yarnpkg.com/browserify-shim/-/browserify-shim-3.8.14.tgz#bf1057026932d3253c75ef7dd714f3b877edec6b"
+  integrity sha1-vxBXAmky0yU8de991xTzuHft7Gs=
+  dependencies:
+    exposify "~0.5.0"
+    mothership "~0.2.0"
+    rename-function-calls "~0.1.0"
+    resolve "~0.6.1"
+    through "~2.3.4"
+
 browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
@@ -2922,6 +3215,11 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+bzip2@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/bzip2/-/bzip2-0.1.1.tgz#b0d232bd0f0f750d2023306d40a886ee51b901f4"
+  integrity sha1-sNIyvQ8PdQ0gIzBtQKiG7lG5AfQ=
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -3127,7 +3425,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-css@4.2.3:
+clean-css@4.2.3, clean-css@^4.1.5:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
@@ -3490,7 +3788,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css@^2.0.0:
+css@^2.0.0, css@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -3702,6 +4000,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
 del@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/del/-/del-1.2.1.tgz#aed6e5bcd7cb7325df34f563125fa265b2c1a014"
@@ -3754,6 +4057,22 @@ detect-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detective@^4.5.0:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.1.tgz#0eca7314338442febb6d65da54c10bb1c82b246e"
+  integrity sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==
+  dependencies:
+    acorn "^5.2.1"
+    defined "^1.0.0"
+
+detective@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-3.1.0.tgz#77782444ab752b88ca1be2e9d0a0395f1da25eed"
+  integrity sha1-d3gkRKt1K4jKG+Lp0KA5Xx2iXu0=
+  dependencies:
+    escodegen "~1.1.0"
+    esprima-fb "3001.1.0-dev-harmony-fb"
+
 dev-ip@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dev-ip/-/dev-ip-1.0.1.tgz#a76a3ed1855be7a012bb8ac16cb80f3c00dc28f0"
@@ -3789,6 +4108,11 @@ domutils@1.3:
   integrity sha1-mtTVm1r2ymhMYv5tdo7xcOcN8ZI=
   dependencies:
     domelementtype "1"
+
+dot-parts@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dot-parts/-/dot-parts-1.0.1.tgz#884bd7bcfc3082ffad2fe5db53e494d8f3e0743f"
+  integrity sha1-iEvXvPwwgv+tL+XbU+SU2PPgdD8=
 
 duplexer2@0.0.2, duplexer2@~0.0.2:
   version "0.0.2"
@@ -4041,6 +4365,11 @@ es6-iterator@^2.0.1, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-promise@^4.2.5:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
@@ -4086,6 +4415,17 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escodegen@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.1.0.tgz#c663923f6e20aad48d0c0fa49f31c6d4f49360cf"
+  integrity sha1-xmOSP24gqtSNDA+knzHG1PSTYM8=
+  dependencies:
+    esprima "~1.0.4"
+    estraverse "~1.5.0"
+    esutils "~1.0.0"
+  optionalDependencies:
+    source-map "~0.1.30"
 
 eslint-plugin-compat@^3.9.0:
   version "3.9.0"
@@ -4183,6 +4523,11 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
+esprima-fb@3001.1.0-dev-harmony-fb:
+  version "3001.1.0-dev-harmony-fb"
+  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz#b77d37abcd38ea0b77426bb8bc2922ce6b426411"
+  integrity sha1-t303q8046gt3Qmu4vCkizmtCZBE=
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -4217,10 +4562,20 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estraverse@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
+  integrity sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+esutils@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.0.0.tgz#8151d358e20c8acc7fb745e7472c0025fe496570"
+  integrity sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=
 
 etag@1.8.1, etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
@@ -4274,6 +4629,17 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   dependencies:
     homedir-polyfill "^1.0.1"
+
+exposify@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/exposify/-/exposify-0.5.0.tgz#f92d0094c265b3f553e1fa456a03a1883d1059cc"
+  integrity sha1-+S0AlMJls/VT4fpFagOhiD0QWcw=
+  dependencies:
+    globo "~1.1.0"
+    map-obj "~1.0.1"
+    replace-requires "~1.0.3"
+    through2 "~0.4.0"
+    transformify "~0.1.1"
 
 ext@^1.1.2:
   version "1.4.0"
@@ -4408,6 +4774,19 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-node-modules@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/find-node-modules/-/find-node-modules-2.1.2.tgz#57565a3455baf671b835bc6b2134a9b938b9c53c"
+  integrity sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==
+  dependencies:
+    findup-sync "^4.0.0"
+    merge "^2.1.0"
+
+find-parent-dir@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -4449,6 +4828,16 @@ findup-sync@^3.0.0:
     detect-file "^1.0.0"
     is-glob "^4.0.0"
     micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
+
+findup-sync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-4.0.0.tgz#956c9cdde804052b881b428512905c4a5f2cdef0"
+  integrity sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^4.0.0"
+    micromatch "^4.0.2"
     resolve-dir "^1.0.1"
 
 fined@^1.0.1:
@@ -4521,6 +4910,11 @@ for-own@^1.0.0:
   integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
   dependencies:
     for-in "^1.0.1"
+
+foreachasync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
+  integrity sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -4634,6 +5028,11 @@ geo-data-exchange@alexcojocaru/geo-data-exchange#v1.1.0:
   resolved "https://codeload.github.com/alexcojocaru/geo-data-exchange/tar.gz/502d3c0180462be022dab7d470ac737f972c312b"
   dependencies:
     leaflet "^1.5.0"
+
+geojson-bounds@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/geojson-bounds/-/geojson-bounds-1.0.2.tgz#c4f6e64223b8c919436707fe1acfabe93145b986"
+  integrity sha512-VTVisOF00DPgIl5xodFx5xyt2XPMXsz2CIAAxFMAtXbrOJjz2gwgzkGQtLEQuuSztn4plIy3Cgravc3QTu9S/A==
 
 geojson-equality@0.1.6:
   version "0.1.6"
@@ -4864,6 +5263,15 @@ globby@^2.0.0:
     async "^1.2.1"
     glob "^5.0.3"
     object-assign "^3.0.0"
+
+globo@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/globo/-/globo-1.1.0.tgz#0d26098955dea422eb2001b104898b0a101caaf3"
+  integrity sha1-DSYJiVXepCLrIAGxBImLChAcqvM=
+  dependencies:
+    accessory "~1.1.0"
+    is-defined "~1.0.0"
+    ternary "~1.0.0"
 
 glogg@^1.0.0:
   version "1.0.2"
@@ -5247,6 +5655,13 @@ has-gulplog@^0.1.0:
   dependencies:
     sparkles "^1.0.0"
 
+has-require@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/has-require/-/has-require-1.2.2.tgz#921675ab130dbd9768fc8da8f1a8e242dfa41774"
+  integrity sha1-khZ1qxMNvZdo/I2o8ajiQt+kF3Q=
+  dependencies:
+    escape-string-regexp "^1.0.3"
+
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
@@ -5300,6 +5715,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+haversine@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/haversine/-/haversine-1.1.1.tgz#05b65e0445aca8f217b0db56877e4d637d3fc8ae"
+  integrity sha512-KW4MS8+krLIeiw8bF5z532CptG0ZyGGFj0UbKMxx25lKnnJ1hMUbuzQl+PXQjNiDLnl1bOyz23U6hSK10r4guw==
+
 homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
@@ -5311,6 +5731,11 @@ hosted-git-info@^2.1.4:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
   integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
+
+html-escape@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-escape/-/html-escape-2.0.0.tgz#60c8ddd465edf0cae02af9e99fdf5f883b09be49"
+  integrity sha1-YMjd1GXt8MrgKvnpn99fiDsJvkk=
 
 htmlparser2@3.5.1:
   version "3.5.1"
@@ -5654,6 +6079,11 @@ is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-defined@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-defined/-/is-defined-1.0.0.tgz#1f07ca67d571f594c4b14415a45f7bef88f92bf5"
+  integrity sha1-HwfKZ9Vx9ZTEsUQVpF9774j5K/U=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -6295,6 +6725,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locutus@^2.0.11:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.14.tgz#53d259ac7200b0621ed4e5604b6c49993415a455"
+  integrity sha512-0H1o1iHNEp3kJ5rW57bT/CAP5g6Qm0Zd817Wcx2+rOMTYyIJoc482Ja1v9dB6IUjwvWKcBNdYi7x2lRXtlJ3bA==
+  dependencies:
+    es6-promise "^4.2.5"
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -6439,10 +6876,20 @@ lodash@^4.17.10, lodash@^4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.11, lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lokijs@^1.5.11:
+  version "1.5.11"
+  resolved "https://registry.yarnpkg.com/lokijs/-/lokijs-1.5.11.tgz#2b2ea82ec66050e4b112c6cfc588dac22d362b13"
+  integrity sha512-YYyuBPxMn/oS0tFznQDbIX5XL1ltMcwFqCboDr8voYE4VCDzR5vAsrvQDhlnua4lBeqMqHmLvUXRTmRUzUKH1Q==
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6498,7 +6945,7 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-map-obj@^1.0.0, map-obj@^1.0.1:
+map-obj@^1.0.0, map-obj@^1.0.1, map-obj@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
@@ -6564,6 +7011,11 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-2.1.1.tgz#59ef4bf7e0b3e879186436e8481c06a6c162ca98"
+  integrity sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==
+
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -6620,7 +7072,7 @@ mime@1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
-mime@^1.3.4:
+mime@^1.3.4, mime@^1.3.6:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -6630,7 +7082,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.x, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6691,6 +7143,13 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mothership@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/mothership/-/mothership-0.2.0.tgz#93d48a2fbc3e50e2a5fc8ed586f5bc44c65f9a99"
+  integrity sha1-k9SKL7w+UOKl/I7VhvW8RMZfmpk=
+  dependencies:
+    find-parent-dir "~0.3.0"
 
 mri@^1.1.5:
   version "1.1.6"
@@ -6766,6 +7225,14 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nearest-point-on-geometry@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nearest-point-on-geometry/-/nearest-point-on-geometry-1.0.1.tgz#5c850936fe3be712cd4069ddca208d2755f84f48"
+  integrity sha1-XIUJNv475xLNQGndyiCNJ1X4T0g=
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^6.0.1"
+    "@turf/nearest-point-on-line" "^6.0.2"
 
 needle@^2.2.1:
   version "2.4.0"
@@ -7148,6 +7615,43 @@ osmtogeojson@^3.0.0-beta.4:
   optionalDependencies:
     "@types/geojson" "^1.0.2"
 
+overpass-frontend@^2.4.13:
+  version "2.4.13"
+  resolved "https://registry.yarnpkg.com/overpass-frontend/-/overpass-frontend-2.4.13.tgz#aaef2d2825ec044f0966a700d218ddf786b544c2"
+  integrity sha512-88llwSFmfeYHDZJd8eHqygUEYMH4n3kps+z1TbIKU7g9b/VuQcqjgQuPkdzgDAFIGv71P/8GPPKIevnFWWFytg==
+  dependencies:
+    "@turf/bbox-clip" "^6.0.3"
+    "@turf/difference" "^6.0.2"
+    "@turf/intersect" "^6.1.3"
+    "@turf/union" "^6.0.3"
+    async "^3.2.0"
+    boundingbox "^1.2.3"
+    browserify-shim "^3.8.14"
+    bzip2 "^0.1.1"
+    event-emitter "^0.3.5"
+    lodash "^4.17.20"
+    lokijs "^1.5.11"
+    osmtogeojson "^3.0.0-beta.4"
+    strsearch2regexp "^0.1.1"
+    weight-sort "^1.3.1"
+    xmlhttprequest "*"
+
+overpass-layer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/overpass-layer/-/overpass-layer-3.0.0.tgz#95ca41cf1f6020cf4c51981f68429c1cf62c0f04"
+  integrity sha512-1ZlVJ0ppC5rYVi1zd6lii8f2bH89C7tBNWFsQnqPg7eQqZ3DkcdzVW3goPxV/CgxZUS1r4Ke55ST7eS1mxmiWg==
+  dependencies:
+    "@turf/along" "^6.0.1"
+    "@turf/length" "^6.0.2"
+    "@turf/point-on-feature" "^5.1.5"
+    boundingbox "^1.2.3"
+    browserify-css "^0.15.0"
+    event-emitter "^0.3.5"
+    html-escape "^2.0.0"
+    nearest-point-on-geometry "^1.0.1"
+    overpass-frontend "^2.4.13"
+    twig "^1.15.4"
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -7242,6 +7746,11 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-text@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/patch-text/-/patch-text-1.0.2.tgz#4bf36e65e51733d6e98f0cf62e09034daa0348ac"
+  integrity sha1-S/NuZeUXM9bpjwz2LgkDTaoDSKw=
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -7905,6 +8414,13 @@ remove-trailing-separator@^1.0.1, remove-trailing-separator@^1.1.0:
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
+rename-function-calls@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/rename-function-calls/-/rename-function-calls-0.1.1.tgz#7f83369c007a3007f6abe3033ccf81686a108e01"
+  integrity sha1-f4M2nAB6MAf2q+MDPM+BaGoQjgE=
+  dependencies:
+    detective "~3.1.0"
+
 repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
@@ -7940,6 +8456,16 @@ replace-homedir@^1.0.0:
     homedir-polyfill "^1.0.1"
     is-absolute "^1.0.0"
     remove-trailing-separator "^1.1.0"
+
+replace-requires@~1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/replace-requires/-/replace-requires-1.0.4.tgz#014b7330b6b9e2557b71043b66fb02660c3bf667"
+  integrity sha1-AUtzMLa54lV7cQQ7ZvsCZgw79mc=
+  dependencies:
+    detective "^4.5.0"
+    has-require "~1.2.1"
+    patch-text "~1.0.2"
+    xtend "~4.0.0"
 
 replacestream@^4.0.0:
   version "4.0.3"
@@ -8058,6 +8584,11 @@ resolve@^1.4.0:
   integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
   dependencies:
     path-parse "^1.0.6"
+
+resolve@~0.6.1:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
+  integrity sha1-3ZV5gufnNt699TtYpN2RdUV13UY=
 
 resp-modifier@6.0.2:
   version "6.0.2"
@@ -8473,6 +9004,13 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@~0.1.30:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
+
 sparkles@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
@@ -8768,6 +9306,13 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-css-comments@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-css-comments/-/strip-css-comments-3.0.0.tgz#7a5625eff8a2b226cf8947a11254da96e13dae89"
+  integrity sha1-elYl7/iisibPiUehElTaluE9rok=
+  dependencies:
+    is-regexp "^1.0.0"
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -8789,6 +9334,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strsearch2regexp@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strsearch2regexp/-/strsearch2regexp-0.1.1.tgz#3e9ddb1df93c2552b49eef9ae3c7db23e53102d6"
+  integrity sha512-JW28a7y9IE2LpIqV4fJ7IOjTsO/5udSXF1pkeDB+AR4/PWtN9rLmZN134tFYwkcuCwA6QIYEB8l3jILtuMFm8w==
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -8869,6 +9419,11 @@ ternary-stream@^3.0.0:
     merge-stream "^2.0.0"
     through2 "^3.0.1"
 
+ternary@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ternary/-/ternary-1.0.0.tgz#45702725608c9499d46a9610e9b0e49ff26f789e"
+  integrity sha1-RXAnJWCMlJnUapYQ6bDkn/JveJ4=
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -8895,6 +9450,14 @@ through2-filter@^3.0.0:
     through2 "~2.0.0"
     xtend "~4.0.0"
 
+through2@2.0.x, through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
 through2@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
@@ -8909,14 +9472,6 @@ through2@^0.5.0:
   dependencies:
     readable-stream "~1.0.17"
     xtend "~3.0.0"
-
-through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
-  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
-  dependencies:
-    readable-stream "~2.3.6"
-    xtend "~4.0.1"
 
 through2@^3.0.1:
   version "3.0.2"
@@ -8941,6 +9496,14 @@ through2@~0.2.3:
     readable-stream "~1.1.9"
     xtend "~2.1.1"
 
+through2@~0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
+  integrity sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~2.1.1"
+
 through2@~0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
@@ -8949,7 +9512,7 @@ through2@~0.6.3:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through@2, through@^2.3.6, through@^2.3.8:
+through@2, through@^2.3.6, through@^2.3.8, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -9120,6 +9683,13 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
+transformify@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/transformify/-/transformify-0.1.2.tgz#9a4f42a154433dd727b80575428a3c9e5489ebf1"
+  integrity sha1-mk9CoVRDPdcnuAV1Qoo8nlSJ6/E=
+  dependencies:
+    readable-stream "~1.1.9"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -9141,6 +9711,16 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+twig@^1.15.4:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/twig/-/twig-1.15.4.tgz#314b00eaf98a57e70ed7dcfd6def93d0d8f3d627"
+  integrity sha512-gRpGrpdf+MswqF6eSjEdYZTa/jt3ZWHK/NU59IbTYJMBQXJ1W+7IxaGEwLkQjd+mNT15j9sQTzQumxUBkuQueQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    locutus "^2.0.11"
+    minimatch "3.0.x"
+    walk "2.3.x"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -9416,6 +9996,18 @@ vinyl@^2.0.0, vinyl@^2.0.1, vinyl@^2.1.0, vinyl@^2.2.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
+walk@2.3.x:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  integrity sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==
+  dependencies:
+    foreachasync "^3.0.0"
+
+weight-sort@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/weight-sort/-/weight-sort-1.3.1.tgz#a97c22f2f67aba95e356caea8ade35b22cb12f25"
+  integrity sha512-RjG1sFtn0lMOsbdE9YnN2xA7ccKRWMGN71Z+bLeZ1qqMg1z3kcspCJQajBKGHdqXugGr2z80ENhf3B/UdF2aCw==
+
 wgs84@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
@@ -9517,6 +10109,11 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+
+xmlhttprequest@*:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
+  integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This adds a (yet pretty simple) Overpass API based POI layer.  To achieve this it integrates the MIT-licensed overpass-layer module, which runs overpass queries for the full bounding box (i.e. no "search along the route"), and uses a map marker quite like the existing POI marker (but with `fa-search` icon instead of `fa-star`). The popups list the OSM-style key/value pairs without much interpretation.

Overpass layers can be added in two ways:
* as default layers, with .geojson files residing statically below layers/overpass/
* as custom layers, that can be added dynamically by the user

Regarding the default layers I was wondering how many of those layers should be added (or if any at all), and how specific they should be e.g. to cycling needs (e.g. water sources of different kinds) or general purpose (one special kind of amenity per layer). This PR is currently leaning towards the latter and just adds a whole lot of amenities, shops & tourism osm features --- likely too many.

With the custom layers dialog I was also wondering, how things can be achieved in a user friendly way ... so far it's pretty cryptic (mainly since I refrained from just putting documentation into it or adding actual labels to the inputs).  So instead of an URL you can put a Overpass Query (like e.g. `(node[shop]['diet:vegan']['diet:vegan'!=no]; way[shop]['diet:vegan']['diet:vegan'!=no];);`) in the URL input field, provide a layer name and click "add overpass query".

Both kinds of layers then can be checked on and off in the layer control like normal.

For the moment I'd consider this a minimal baseline, on which sub-sequent features could be built -- like choosing a color for the layer (which could be of interest to the gpx import layers as well)

refs #106 