### PR TITLE
Route Loader Keyboard Shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,12 +78,14 @@
                             aria-haspopup="true"
                             aria-expanded="false"
                             data-i18n="[title]navbar.load.tooltip"
-                            data-i18n-options="{
-                                'tracksAction': '$t(navbar.load.tracks)',
-                                'tracksKey': 'O',
-                                'nogosAction': '$t(navbar.load.nogos)',
-                                'nogosKey': '$t(keyboard.shift)+O'
-                            }"
+                            data-i18n-options='{
+                                "tracksAction": "$t(navbar.load.tracks)",
+                                "tracksKey": "O",
+                                "trackAsRouteAction": "$t(trackasroute.title)",
+                                "trackAsRouteKey": "$t(keyboard.shift)+O",
+                                "nogosAction": "$t(navbar.load.nogos)",
+                                "nogosKey": "$t(keyboard.shift)+N"
+                            }'
                             title="Load route"
                         >
                             <span class="fa fa-lg fa-cloud-upload" aria-hidden="true"> </span>

--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -5,6 +5,7 @@ BR.NogoAreas = L.Control.extend({
                 enable: 78, // char code for 'n'
                 disable: 27, // char code for 'ESC'
             },
+            import: 78, // char code for 'n'; used in conjunction with 'shift'
         },
     },
 
@@ -147,6 +148,13 @@ BR.NogoAreas = L.Control.extend({
         if (!BR.Util.keyboardShortcutsAllowed(e)) {
             return;
         }
+
+        if (true === e.shiftKey && e.keyCode === this.options.shortcut.import) {
+            $('#loadNogos').modal('show');
+
+            return;
+        }
+
         if (e.keyCode === this.options.shortcut.draw.disable && this.button.state() === BR.NogoAreas.STATE_CANCEL) {
             this.stopDrawing(this.button);
         } else if (

--- a/js/plugin/RouteLoaderConverter.js
+++ b/js/plugin/RouteLoaderConverter.js
@@ -15,6 +15,9 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
             simplifyTolerance: -1,
             isTestMode: false,
             simplifyLastKnownGood: 0.001,
+            shortcut: {
+                open: 82, // char code for 'r'
+            },
         },
 
         setDialogDraggable: function (jqDlgHeader) {
@@ -90,6 +93,9 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
                 simplifyTolerance: -1,
                 isTestMode: false,
                 simplifyLastKnownGood: 0.001,
+                shortcut: {
+                    open: 82, // char code for 'r'
+                },
             };
         },
 
@@ -223,6 +229,8 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
                     this.onManualCollapse(e);
                 }.bind(this)
             );
+
+            L.DomEvent.addListener(document, 'keydown', this.keydownListener, this);
 
             // dummy, no own representation, delegating to EasyButton
             var dummy = L.DomUtil.create('div');
@@ -382,6 +390,13 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
 
             this.onBusyChanged(false);
         },
+
+        keydownListener: function (e) {
+            if (BR.Util.keyboardShortcutsAllowed(e) && e.keyCode === this._options.shortcut.open) {
+                $('#navbarLoadEditTracks').click();
+            }
+        },
+
     });
 
     RouteLoader.include(L.Evented.prototype);

--- a/js/plugin/RouteLoaderConverter.js
+++ b/js/plugin/RouteLoaderConverter.js
@@ -87,7 +87,6 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
             (this._bounds = undefined), (this._trackPoints = []);
             this._currentGeoJSON = {};
             this._options = {
-                ext: 'gpx',
                 showTrackLayer: true,
                 showPointAsPoi: true,
                 simplifyTolerance: -1,
@@ -396,7 +395,6 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
                 $('#navbarLoadEditTracks').click();
             }
         },
-
     });
 
     RouteLoader.include(L.Evented.prototype);

--- a/js/plugin/RouteLoaderConverter.js
+++ b/js/plugin/RouteLoaderConverter.js
@@ -16,7 +16,7 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
             isTestMode: false,
             simplifyLastKnownGood: 0.001,
             shortcut: {
-                open: 82, // char code for 'r'
+                open: 79, // char code for 'O'; used in conjunction with 'shift'
             },
         },
 
@@ -93,7 +93,7 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
                 isTestMode: false,
                 simplifyLastKnownGood: 0.001,
                 shortcut: {
-                    open: 82, // char code for 'r'
+                    open: 79, // char code for 'O'; used in conjunction with 'shift'
                 },
             };
         },
@@ -391,7 +391,11 @@ BR.routeLoader = function (map, layersControl, routing, pois) {
         },
 
         keydownListener: function (e) {
-            if (BR.Util.keyboardShortcutsAllowed(e) && e.keyCode === this._options.shortcut.open) {
+            if (
+                BR.Util.keyboardShortcutsAllowed(e) &&
+                e.keyCode === this._options.shortcut.open &&
+                true === e.shiftKey
+            ) {
                 $('#navbarLoadEditTracks').click();
             }
         },

--- a/js/plugin/TracksLoader.js
+++ b/js/plugin/TracksLoader.js
@@ -61,12 +61,12 @@ BR.tracksLoader = function (map, layersControl, routing, pois) {
         },
 
         _keydownListener: function (e) {
-            if (BR.Util.keyboardShortcutsAllowed(e) && e.keyCode === this.options.shortcut.open) {
-                if (e.shiftKey) {
-                    $('#loadNogos').modal('show');
-                } else {
-                    $('#navbarLoadTracks')[0].click();
-                }
+            if (
+                BR.Util.keyboardShortcutsAllowed(e) &&
+                e.keyCode === this.options.shortcut.open &&
+                false === e.shiftKey
+            ) {
+                $('#navbarLoadTracks')[0].click();
             }
         },
     });

--- a/locales/en.json
+++ b/locales/en.json
@@ -174,8 +174,9 @@
     "load": {
       "nogos": "Load no-go areas",
       "title": "Load",
-      "tooltip": "{{tracksAction}} ({{tracksKey}} key)\n{{nogosAction}} ({{nogosKey}})",
-      "tracks": "Load tracks"
+      "tooltip": "{{tracksAction}} ({{tracksKey}} key)\n{{trackAsRouteAction}} ({{trackAsRouteKey}})\n{{nogosAction}} ({{nogosKey}})",
+      "tracks": "Load tracks",
+      "trackAsRoute": "Load Track as Route"
     },
     "profile": {
       "car-eco": "Car (economic)",


### PR DESCRIPTION
This pull request enables opening the “import as route” by pressing `r` (for “route”) on the keyboard.

Additionally, an unused option value is removed from the `cleanup()` method.