### PR TITLE
Improve typography for "What's new?" dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -447,11 +447,6 @@ button.btn {
 }
 
 /* "What's new?" (Change Log) */
-#whatsnew h1 {
-    margin-bottom: 1rem;
-    font-size: 1.5rem;
-}
-
 #whatsnew h2 {
     margin: 2rem 0;
     border-bottom: 1px solid #dee2e6;

--- a/css/style.css
+++ b/css/style.css
@@ -446,6 +446,24 @@ button.btn {
     margin: -6px 0 6px 20px;
 }
 
+/* "What's new?" (Change Log) */
+#whatsnew h1 {
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+}
+
+#whatsnew h2 {
+    margin: 2rem 0;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 0.5rem;
+    font-size: 1.3rem;
+}
+
+#whatsnew h3 {
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+}
+
 /*
 * DataTables
 */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,6 +189,7 @@ gulp.task('boundaries', function () {
 
 gulp.task('changelog', function (cb) {
     var content = 'BR.changelog = `' + marked(fs.readFileSync('./CHANGELOG.md', 'utf-8')) + '`';
+    content = content.replace(/<h1.*<\/h1>/i, '');
     fs.writeFile(paths.dest + '/changelog.js', content, cb);
 });
 


### PR DESCRIPTION
This pull request improves the readability in the “What’s New?” dialog by adjustung the font-sizes and margin for the headlines (`<h2>`, `<h3>`).

Additionally, the `<h1>` is removed as it has no substantial value.

Before:

![Changelog Old](https://static.marcusjaschen.de/dump/covert/7iver1i7yd2crnoj7vzngr08u9icw16appvrzjxc/changelog-old.png)

After:

![Changelog New](https://static.marcusjaschen.de/dump/covert/lrqfvmk9rzvrjwcmn4d00wurbcv6t32yq0nlq5rk/changelog-new.png)
