### PR TITLE
Fix for flickering search field on Firefox @ Android

### DIFF
--- a/js/plugin/Search.js
+++ b/js/plugin/Search.js
@@ -10,6 +10,7 @@ BR.Search = class extends L.Control.Geocoder {
                         sizeInMeters: 800,
                     }),
                     position: 'topleft',
+                    expand: 'click',
                     shortcut: {
                         search: 70, // char code for 'f'
                     },


### PR DESCRIPTION
This pull request fixes the flickering search field on Firefox @ Android. Tested with Firefox latest running on Android 9 (Nokia 8). Also verified with other browsers (Android: Chrome, Edge; iOS: Safari/WebView; Desktop: Firefox, Brave).

The fix is deployed to my BRouter-Web instance and can be tested: [brouter.m11n.de](https://brouter.m11n.de/)