### PR TITLE
Use L.Marker in Overpass layer + maki/temaki icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ Copyright (c) 2018 Norbert Renner and [contributors](https://github.com/nrenner/
     Copyright (c) 2014-present, Facebook, Inc.; [MIT License](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/LICENSE)
 -   [overpass-layer](https://github.com/plepe/overpass-layer)
     Copyright (c) 2020 Stephan Bösch-Plepelits; [MIT License](https://github.com/plepe/overpass-layer/blob/master/LICENSE)
+-   [maki](https://github.com/mapbox/maki)
+    [CC0-1.0 License](https://github.com/mapbox/maki/blob/master/LICENSE.txt)
+-   [temaki](https://github.com/ideditor/temaki)
+    [CC0-1.0 License](https://github.com/ideditor/temaki/blob/main/LICENSE.md)

--- a/css/style.css
+++ b/css/style.css
@@ -54,13 +54,21 @@ table.dataTable {
     vertical-align: top;
 }
 
-.overpass-layer-icon i {
+.overpass-layer-icon .sign > * {
     position: absolute;
     top: -34px;
-    color: white;
     margin: auto;
     display: inline-block;
     font-size: 11px;
+}
+
+.overpass-layer-icon .icon-white {
+    color: white;
+}
+
+.overpass-layer-icon .icon-invert {
+    -webkit-filter: invert(1);
+    filter: invert(1);
 }
 
 /* wrap toolbar controls */

--- a/css/style.css
+++ b/css/style.css
@@ -54,6 +54,15 @@ table.dataTable {
     vertical-align: top;
 }
 
+.overpass-layer-icon i {
+    position: absolute;
+    top: -34px;
+    color: white;
+    margin: auto;
+    display: inline-block;
+    font-size: 11px;
+}
+
 /* wrap toolbar controls */
 .leaflet-top.leaflet-left {
     bottom: 0;

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -193,9 +193,14 @@ BR.LayersConfig = L.Class.extend({
                     title: '{{ tags.name }}',
                     body:
                         '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
-                    markerSymbol: null,
+                    markerSymbol:
+                        '<svg width="25px" height="41px" anchorX="12" anchorY="41" viewBox="0 0 32 52" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M16,1 C7.7146,1 1,7.65636364 1,15.8648485 C1,24.0760606 16,51 16,51 C16,51 31,24.0760606 31,15.8648485 C31,7.65636364 24.2815,1 16,1 L16,1 Z" fill="#436978"></path></svg>',
+                    markerSign: '<i class="fa fa-search icon-white" style="width: 25px;"></i>',
                     style: function (overpassObject) {
-                        return this.defaultBaseLayers?.[0] === 'cyclosm' ? { color: 'darkorange' } : {};
+                        return {
+                            nodeFeature: 'Marker',
+                            color: this.defaultBaseLayers?.[0] === 'cyclosm' ? 'darkorange' : '#3388ff',
+                        };
                     }.bind(this),
                 },
             }),

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -206,8 +206,13 @@ BR.LayersConfig = L.Class.extend({
                     markerSign,
                     style: function (overpassObject) {
                         return {
-                            nodeFeature: 'Marker',
-                            color: this.defaultBaseLayers?.[0] === 'cyclosm' ? 'darkorange' : '#3388ff',
+                            // nodeFeature: 'Marker' isn't currently working well, hence use transparent circle color for nodes
+                            color:
+                                overpassObject.type === 'node'
+                                    ? '#00000000'
+                                    : this.defaultBaseLayers?.[0] === 'cyclosm'
+                                    ? 'darkorange'
+                                    : '#3388ff',
                         };
                     }.bind(this),
                 },

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -188,6 +188,8 @@ BR.LayersConfig = L.Class.extend({
 
         if (icon && icon.startsWith('maki-')) {
             markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(5)}-11.svg" />`;
+        } else if (icon && icon.startsWith('temaki-')) {
+            markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(7)}.svg" width="11" />`;
         }
 
         return Object.assign(

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -183,7 +183,13 @@ BR.LayersConfig = L.Class.extend({
         }
     },
 
-    createOverpassLayer: function (query) {
+    createOverpassLayer: function (query, icon) {
+        let markerSign = '<i class="fa fa-search icon-white" style="width: 25px;"></i>';
+
+        if (icon && icon.startsWith('maki-')) {
+            markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(5)}-11.svg" />`;
+        }
+
         return Object.assign(
             new OverpassLayer({
                 overpassFrontend: this.overpassFrontend,
@@ -195,7 +201,7 @@ BR.LayersConfig = L.Class.extend({
                         '<table class="overpass-tags">{% for k, v in tags %}{% if k[:5] != "addr:" %}<tr><th>{{ k }}</th><td>{% if k matches "/email/" %}<a href="mailto:{{ v }}">{{ v }}</a>{% elseif v matches "/^http/" %}<a href="{{ v }}">{{ v }}</a>{% elseif v matches "/^www/" %}<a href="http://{{ v }}">{{ v }}</a>{% else %}{{ v }}{% endif %}</td></tr>{% endif %}{% endfor %}</table>',
                     markerSymbol:
                         '<svg width="25px" height="41px" anchorX="12" anchorY="41" viewBox="0 0 32 52" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M16,1 C7.7146,1 1,7.65636364 1,15.8648485 C1,24.0760606 16,51 16,51 C16,51 31,24.0760606 31,15.8648485 C31,7.65636364 24.2815,1 16,1 L16,1 Z" fill="#436978"></path></svg>',
-                    markerSign: '<i class="fa fa-search icon-white" style="width: 25px;"></i>',
+                    markerSign,
                     style: function (overpassObject) {
                         return {
                             nodeFeature: 'Marker',
@@ -294,7 +300,7 @@ BR.LayersConfig = L.Class.extend({
                 layer.subdomains = props.subdomains;
             }
         } else if (props.dataSource === 'OverpassAPI') {
-            layer = this.createOverpassLayer(props.query);
+            layer = this.createOverpassLayer(props.query, props.icon);
         } else {
             // JOSM
             var josmUrl = url;

--- a/layers/overpass/amenity/financial/atm.geojson
+++ b/layers/overpass/amenity/financial/atm.geojson
@@ -5,6 +5,7 @@
     "id": "atm",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-bank",
     "query": "(nwr[amenity=atm]; nwr[amenity=bank][atm][atm!=no];);"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/financial/bank.geojson
+++ b/layers/overpass/amenity/financial/bank.geojson
@@ -5,6 +5,7 @@
     "id": "bank",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-bank",
     "query": "nwr[amenity=bank];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/bench.geojson
+++ b/layers/overpass/amenity/others/bench.geojson
@@ -5,6 +5,7 @@
     "id": "bench",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-bench",
     "query": "nwr[amenity=bench];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/kneipp_water_cure.geojson
+++ b/layers/overpass/amenity/others/kneipp_water_cure.geojson
@@ -5,6 +5,7 @@
     "id": "kneipp_water_cure",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-hospital",
     "query": "nwr[amenity=kneipp_water_cure];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/public_bath.geojson
+++ b/layers/overpass/amenity/others/public_bath.geojson
@@ -5,6 +5,7 @@
     "id": "public_bath",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-water",
     "query": "nwr[amenity=public_bath];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/shelter.geojson
+++ b/layers/overpass/amenity/others/shelter.geojson
@@ -5,6 +5,7 @@
     "id": "shelter",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-shelter",
     "query": "nwr[amenity=shelter];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/shower.geojson
+++ b/layers/overpass/amenity/others/shower.geojson
@@ -5,6 +5,7 @@
     "id": "shower",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-shower",
     "query": "nwr[amenity=shower];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/telephone.geojson
+++ b/layers/overpass/amenity/others/telephone.geojson
@@ -5,6 +5,7 @@
     "id": "telephone",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-phone-alt",
     "query": "nwr[amenity=telephone];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/toilets.geojson
+++ b/layers/overpass/amenity/others/toilets.geojson
@@ -5,6 +5,7 @@
     "id": "toilets",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-toilet",
     "query": "nwr[amenity=toilets];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/others/water_point.geojson
+++ b/layers/overpass/amenity/others/water_point.geojson
@@ -5,6 +5,7 @@
     "id": "water_point",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-drinking-water",
     "query": "nwr[amenity=water_point];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/bar.geojson
+++ b/layers/overpass/amenity/sustenance/bar.geojson
@@ -5,6 +5,7 @@
     "id": "bar",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-bar",
     "query": "nwr[amenity=bar];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/bbq.geojson
+++ b/layers/overpass/amenity/sustenance/bbq.geojson
@@ -5,6 +5,7 @@
     "id": "bbq",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-bbq",
     "query": "nwr[amenity=bbq];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/biergarten.geojson
+++ b/layers/overpass/amenity/sustenance/biergarten.geojson
@@ -5,6 +5,7 @@
     "id": "biergarten",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-beer",
     "query": "nwr[amenity=biergarten];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/cafe.geojson
+++ b/layers/overpass/amenity/sustenance/cafe.geojson
@@ -5,6 +5,7 @@
     "id": "cafe",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-cafe",
     "query": "nwr[amenity=cafe];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/drinking_water.geojson
+++ b/layers/overpass/amenity/sustenance/drinking_water.geojson
@@ -5,6 +5,7 @@
     "id": "drinking_water",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-drinking-water",
     "query": "nwr[amenity=drinking_water];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/fast_food.geojson
+++ b/layers/overpass/amenity/sustenance/fast_food.geojson
@@ -5,6 +5,7 @@
     "id": "fast_food",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-fast-food",
     "query": "nwr[amenity=fast_food];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/food_court.geojson
+++ b/layers/overpass/amenity/sustenance/food_court.geojson
@@ -5,6 +5,7 @@
     "id": "food_court",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-restaurant",
     "query": "nwr[amenity=food_court];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/ice_cream.geojson
+++ b/layers/overpass/amenity/sustenance/ice_cream.geojson
@@ -5,6 +5,7 @@
     "id": "ice_cream",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-ice-cream",
     "query": "nwr[amenity=ice_cream];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/pub.geojson
+++ b/layers/overpass/amenity/sustenance/pub.geojson
@@ -5,6 +5,7 @@
     "id": "pub",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-beer",
     "query": "nwr[amenity=pub];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/sustenance/restaurant.geojson
+++ b/layers/overpass/amenity/sustenance/restaurant.geojson
@@ -5,6 +5,7 @@
     "id": "restaurant",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-restaurant",
     "query": "nwr[amenity=restaurant];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/bicycle_parking.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_parking.geojson
@@ -5,6 +5,7 @@
     "id": "bicycle_parking",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-bicycle",
     "query": "nwr[amenity=bicycle_parking];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/bicycle_rental.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_rental.geojson
@@ -5,6 +5,7 @@
     "id": "bicycle_rental",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-bicycle_rental",
     "query": "nwr[amenity=bicycle_rental];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/bicycle_repair_station.geojson
+++ b/layers/overpass/amenity/transportation/bicycle_repair_station.geojson
@@ -5,6 +5,7 @@
     "id": "bicycle_repair_station",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-bicycle_repair",
     "query": "nwr[amenity=bicycle_repair_station];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/boat_rental.geojson
+++ b/layers/overpass/amenity/transportation/boat_rental.geojson
@@ -5,6 +5,7 @@
     "id": "boat_rental",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-boat_rental",
     "query": "nwr[amenity=boat_rental];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/bus_station.geojson
+++ b/layers/overpass/amenity/transportation/bus_station.geojson
@@ -5,6 +5,7 @@
     "id": "bus_station",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-bus",
     "query": "nwr[amenity=bus_station];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/car_rental.geojson
+++ b/layers/overpass/amenity/transportation/car_rental.geojson
@@ -5,6 +5,7 @@
     "id": "car_rental",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-car-rental",
     "query": "nwr[amenity=car_rental];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/car_sharing.geojson
+++ b/layers/overpass/amenity/transportation/car_sharing.geojson
@@ -5,6 +5,7 @@
     "id": "car_sharing",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-sign_and_car",
     "query": "nwr[amenity=car_sharing];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/car_wash.geojson
+++ b/layers/overpass/amenity/transportation/car_wash.geojson
@@ -5,6 +5,7 @@
     "id": "car_wash",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-car_wash",
     "query": "nwr[amenity=car_wash];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/charging_station.geojson
+++ b/layers/overpass/amenity/transportation/charging_station.geojson
@@ -5,6 +5,7 @@
     "id": "charging_station",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-charging-station",
     "query": "nwr[amenity=charging_station];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/ferry_terminal.geojson
+++ b/layers/overpass/amenity/transportation/ferry_terminal.geojson
@@ -5,6 +5,7 @@
     "id": "ferry_terminal",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-ferry",
     "query": "nwr[amenity=ferry_terminal];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/fuel.geojson
+++ b/layers/overpass/amenity/transportation/fuel.geojson
@@ -5,6 +5,7 @@
     "id": "fuel",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-fuel",
     "query": "nwr[amenity=fuel];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/grit_bin.geojson
+++ b/layers/overpass/amenity/transportation/grit_bin.geojson
@@ -5,6 +5,7 @@
     "id": "grit_bin",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-box",
     "query": "nwr[amenity=grit_bin];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/motorcycle_parking.geojson
+++ b/layers/overpass/amenity/transportation/motorcycle_parking.geojson
@@ -5,6 +5,7 @@
     "id": "motorcycle_parking",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-motorcycle",
     "query": "nwr[amenity=motorcycle_parking];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/parking.geojson
+++ b/layers/overpass/amenity/transportation/parking.geojson
@@ -5,6 +5,7 @@
     "id": "parking",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-car_parked",
     "query": "nwr[amenity=parking];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/parking_entrance.geojson
+++ b/layers/overpass/amenity/transportation/parking_entrance.geojson
@@ -5,6 +5,7 @@
     "id": "parking_entrance",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-entrance-alt1",
     "query": "nwr[amenity=parking_entrance];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/parking_space.geojson
+++ b/layers/overpass/amenity/transportation/parking_space.geojson
@@ -5,6 +5,7 @@
     "id": "parking_space",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-parking_space",
     "query": "nwr[amenity=parking_space];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/taxi.geojson
+++ b/layers/overpass/amenity/transportation/taxi.geojson
@@ -5,6 +5,7 @@
     "id": "taxi",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-taxi",
     "query": "nwr[amenity=taxi];"
   },
   "type": "Feature"

--- a/layers/overpass/amenity/transportation/vehicle_inspection.geojson
+++ b/layers/overpass/amenity/transportation/vehicle_inspection.geojson
@@ -5,6 +5,7 @@
     "id": "vehicle_inspection",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-car",
     "query": "nwr[amenity=vehicle_inspection];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/bakery.geojson
+++ b/layers/overpass/shop/food/bakery.geojson
@@ -5,6 +5,7 @@
     "id": "bakery",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-bakery",
     "query": "nwr[shop=bakery];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/beverages.geojson
+++ b/layers/overpass/shop/food/beverages.geojson
@@ -5,6 +5,7 @@
     "id": "beverages",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-bottles",
     "query": "nwr[shop=beverages];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/butcher.geojson
+++ b/layers/overpass/shop/food/butcher.geojson
@@ -5,6 +5,7 @@
     "id": "butcher",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-cleaver",
     "query": "nwr[shop=butcher];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/cheese.geojson
+++ b/layers/overpass/shop/food/cheese.geojson
@@ -5,6 +5,7 @@
     "id": "cheese",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-cheese",
     "query": "nwr[shop=cheese];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/coffee.geojson
+++ b/layers/overpass/shop/food/coffee.geojson
@@ -5,6 +5,7 @@
     "id": "coffee",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-coffee",
     "query": "nwr[shop=coffee];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/convenience.geojson
+++ b/layers/overpass/shop/food/convenience.geojson
@@ -5,6 +5,7 @@
     "id": "convenience",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-shopping-basket",
     "query": "nwr[shop=convenience];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/greengrocer.geojson
+++ b/layers/overpass/shop/food/greengrocer.geojson
@@ -5,6 +5,7 @@
     "id": "greengrocer",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-carrot",
     "query": "nwr[shop=greengrocer];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/health_food.geojson
+++ b/layers/overpass/shop/food/health_food.geojson
@@ -5,6 +5,7 @@
     "id": "health_food",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-shop",
     "query": "nwr[shop=health_food];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/ice_cream.geojson
+++ b/layers/overpass/shop/food/ice_cream.geojson
@@ -5,6 +5,7 @@
     "id": "ice_cream",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-ice-cream",
     "query": "nwr[shop=ice_cream];"
   },
   "type": "Feature"

--- a/layers/overpass/shop/food/organic.geojson
+++ b/layers/overpass/shop/food/organic.geojson
@@ -5,6 +5,7 @@
     "id": "organic",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-grocery",
     "query": "nwr[shop~'supermarket|convenience'][organic][organic!=no];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/apartment.geojson
+++ b/layers/overpass/tourism/apartment.geojson
@@ -5,6 +5,7 @@
     "id": "apartment",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-lodging",
     "query": "nwr[tourism=apartment];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/artwork.geojson
+++ b/layers/overpass/tourism/artwork.geojson
@@ -5,6 +5,7 @@
     "id": "artwork",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-art-gallery",
     "query": "nwr[tourism=artwork];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/attraction.geojson
+++ b/layers/overpass/tourism/attraction.geojson
@@ -5,6 +5,7 @@
     "id": "attraction",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-star",
     "query": "nwr[tourism=attraction];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/camp_site.geojson
+++ b/layers/overpass/tourism/camp_site.geojson
@@ -5,6 +5,7 @@
     "id": "camp_site",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-campsite",
     "query": "nwr[tourism=camp_site];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/caravan_site.geojson
+++ b/layers/overpass/tourism/caravan_site.geojson
@@ -5,6 +5,7 @@
     "id": "caravan_site",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-camper_trailer",
     "query": "nwr[tourism=caravan_site];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/chalet.geojson
+++ b/layers/overpass/tourism/chalet.geojson
@@ -5,6 +5,7 @@
     "id": "chalet",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-cabin",
     "query": "nwr[tourism=chalet];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/gallery.geojson
+++ b/layers/overpass/tourism/gallery.geojson
@@ -5,6 +5,7 @@
     "id": "gallery",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-art-gallery",
     "query": "nwr[tourism=gallery];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/guest_house.geojson
+++ b/layers/overpass/tourism/guest_house.geojson
@@ -5,6 +5,7 @@
     "id": "guest_house",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-lodging",
     "query": "nwr[tourism=guest_house];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/hostel.geojson
+++ b/layers/overpass/tourism/hostel.geojson
@@ -5,6 +5,7 @@
     "id": "hostel",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-bunk_beds",
     "query": "nwr[tourism=hostel];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/hotel.geojson
+++ b/layers/overpass/tourism/hotel.geojson
@@ -5,6 +5,7 @@
     "id": "hotel",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "fas-concierge-bell",
     "query": "nwr[tourism=hotel];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/information.geojson
+++ b/layers/overpass/tourism/information.geojson
@@ -5,6 +5,7 @@
     "id": "information",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-information",
     "query": "nwr[tourism=information];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/motel.geojson
+++ b/layers/overpass/tourism/motel.geojson
@@ -5,6 +5,7 @@
     "id": "motel",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-lodging",
     "query": "nwr[tourism=motel];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/museum.geojson
+++ b/layers/overpass/tourism/museum.geojson
@@ -5,6 +5,7 @@
     "id": "museum",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-museum",
     "query": "nwr[tourism=museum];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/picnic_site.geojson
+++ b/layers/overpass/tourism/picnic_site.geojson
@@ -5,6 +5,7 @@
     "id": "picnic_site",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "maki-picnic-site",
     "query": "nwr[tourism=picnic_site];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/viewpoint.geojson
+++ b/layers/overpass/tourism/viewpoint.geojson
@@ -5,6 +5,7 @@
     "id": "viewpoint",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-spotting_scope",
     "query": "nwr[tourism=viewpoint];"
   },
   "type": "Feature"

--- a/layers/overpass/tourism/wilderness_hut.geojson
+++ b/layers/overpass/tourism/wilderness_hut.geojson
@@ -5,6 +5,7 @@
     "id": "wilderness_hut",
     "overlay": true,
     "dataSource": "OverpassAPI",
+    "icon": "temaki-cabin",
     "query": "nwr[tourism=wilderness_hut];"
   },
   "type": "Feature"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ],
     "dependencies": {
         "@bagage/leaflet.restoreview": "1.0.1",
+        "@mapbox/maki": "^6.2.0",
         "@mapbox/polyline": "^0.2.0",
         "@mapbox/togeojson": "^0.16.0",
         "@turf/turf": "^6.2.0",
@@ -282,6 +283,36 @@
         "overpass-layer": {
             "main": [
                 "dist/overpass-layer.js"
+            ]
+        },
+        "@mapbox/maki": {
+            "main": [
+                "icons/art-gallery-11.svg",
+                "icons/bakery-11.svg",
+                "icons/bank-11.svg",
+                "icons/bar-11.svg",
+                "icons/bbq-11.svg",
+                "icons/beer-11.svg",
+                "icons/bicycle-11.svg",
+                "icons/cafe-11.svg",
+                "icons/campsite-11.svg",
+                "icons/car-11.svg",
+                "icons/car-rental-11.svg",
+                "icons/drinking-water-11.svg",
+                "icons/entrance-alt1-11.svg",
+                "icons/fast-food-11.svg",
+                "icons/fuel-11.svg",
+                "icons/grocery-11.svg",
+                "icons/hospital-11.svg",
+                "icons/information-11.svg",
+                "icons/lodging-11.svg",
+                "icons/picnic-site-11.svg",
+                "icons/restaurant-11.svg",
+                "icons/shelter-11.svg",
+                "icons/shop-11.svg",
+                "icons/star-11.svg",
+                "icons/toilet-11.svg",
+                "icons/water-11.svg"
             ]
         }
     }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ],
     "dependencies": {
         "@bagage/leaflet.restoreview": "1.0.1",
+        "@ideditor/temaki": "^5.0.0",
         "@mapbox/maki": "^6.2.0",
         "@mapbox/polyline": "^0.2.0",
         "@mapbox/togeojson": "^0.16.0",
@@ -313,6 +314,30 @@
                 "icons/star-11.svg",
                 "icons/toilet-11.svg",
                 "icons/water-11.svg"
+            ]
+        },
+        "@ideditor/temaki": {
+            "main": [
+                "icons/bench.svg",
+                "icons/shower.svg",
+                "icons/bicycle_rental.svg",
+                "icons/bicycle_repair.svg",
+                "icons/boat_rental.svg",
+                "icons/bus.svg",
+                "icons/sign_and_car.svg",
+                "icons/car_wash.svg",
+                "icons/ferry.svg",
+                "icons/car_parked.svg",
+                "icons/parking_space.svg",
+                "icons/bottles.svg",
+                "icons/cleaver.svg",
+                "icons/coffee.svg",
+                "icons/camper_trailer.svg",
+                "icons/cabin.svg",
+                "icons/bunk_beds.svg",
+                "icons/museum.svg",
+                "icons/spotting_scope.svg",
+                "icons/cabin.svg"
             ]
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,6 +901,11 @@
     minimist "1.2.0"
     sharkdown "^0.1.0"
 
+"@mapbox/maki@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/maki/-/maki-6.2.0.tgz#b61b3e8e7fc7637493e511ac40de0eea62cd1f8b"
+  integrity sha512-iFIRNT3ZpTOw69p2BFFOmQppujpav2PQTLPyL4+bZ5ZIUfdyB5Qtw45CTfPqzzHpP2AZGjEDbSNhGDRcG9/2fw==
+
 "@mapbox/polyline@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@mapbox/polyline/-/polyline-0.2.0.tgz#6e25980744aa22331f94b645a542c02d3fcfee97"

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,11 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@ideditor/temaki@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@ideditor/temaki/-/temaki-5.0.0.tgz#8351b3c47de59e9b98396c2cca49bc3dc2049e0a"
+  integrity sha512-doBSdSEr03uGx+hpe14ELxUkCoJexjwZ4/bPyMaBJjMHXlb8lKtCr7oG7YZTZsuzcFZCYGxfCTQsgpoO42vZnQ==
+
 "@mapbox/geojson-area@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"


### PR DESCRIPTION
As suggested in https://github.com/nrenner/brouter-web/issues/384#issuecomment-805719150, this PR

* uses `L.Marker` instead of `L.Circle` to mark nodes found via Overpass
* adds icon descriptors from [id-tagging-schema presets.json](https://github.com/openstreetmap/id-tagging-schema/blob/9fdecc983443ce75185c2923caae9f7703f2cae4/dist/presets.json#L22359-L22360) to layers config
* shows maki/temaki icons, according to those
* falls back to fa-search icon (custom layers always get the fallback icon currently)

#### caveats

1. overpass-layer currently has an issue with using "nodeFeature=Marker". Initially it works fine - yet after zooming out it reprocesses its' map features and wants to call `setStyle` on it (to possibly update styling info). However `L.Marker` doesn't provide that function (as opposed to `L.Circle` or `L.CircleMarker`). I've reported this upstream at https://github.com/plepe/overpass-layer/issues/7
For the moment I added some kind of a work-around: if it's just a node, the circle color is changed to alpha=0, i.e. made transparent.

2. the id-tagging-schema references some icons from font-awesome 5. Yet we're using version 4.7 currently, which is missing most of the icons. For the moment those `fas-xxx` icons are *not* handled, i.e. the fallback icon (fa-search) is used.
