### PR TITLE
Overpass icon additions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,6 +71,11 @@ table.dataTable {
     filter: invert(1);
 }
 
+.jstree-themeicon-custom {
+    background-size: 11px !important;
+    width: 15px !important;
+}
+
 /* wrap toolbar controls */
 .leaflet-top.leaflet-left {
     bottom: 0;

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -183,15 +183,25 @@ BR.LayersConfig = L.Class.extend({
         }
     },
 
+    getOverpassIconUrl: function (icon) {
+        const iconPrefix = /^(maki|temaki|fas)-/;
+        let iconUrl = null;
+
+        if (icon && iconPrefix.test(icon)) {
+            const iconName = icon.replace(iconPrefix, '');
+            const postfix = icon.startsWith('maki-') ? '-11' : '';
+            iconUrl = `dist/images/${iconName}${postfix}.svg`;
+        }
+
+        return iconUrl;
+    },
+
     createOverpassLayer: function (query, icon) {
         let markerSign = '<i class="fa fa-search icon-white" style="width: 25px;"></i>';
 
-        if (icon && icon.startsWith('maki-')) {
-            markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(5)}-11.svg" />`;
-        } else if (icon && icon.startsWith('temaki-')) {
-            markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(7)}.svg" width="11" />`;
-        } else if (icon && icon.startsWith('fas-')) {
-            markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(4)}.svg" width="11" />`;
+        const iconUrl = this.getOverpassIconUrl(icon);
+        if (iconUrl) {
+            markerSign = `<img class="icon-invert" src="${iconUrl}" width="11" />`;
         }
 
         return Object.assign(

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -190,6 +190,8 @@ BR.LayersConfig = L.Class.extend({
             markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(5)}-11.svg" />`;
         } else if (icon && icon.startsWith('temaki-')) {
             markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(7)}.svg" width="11" />`;
+        } else if (icon && icon.startsWith('fas-')) {
+            markerSign = `<img class="icon-invert" src="dist/images/${icon.substr(4)}.svg" width="11" />`;
         }
 
         return Object.assign(

--- a/js/control/LayersTab.js
+++ b/js/control/LayersTab.js
@@ -170,7 +170,7 @@ BR.LayersTab = BR.ControlLayers.extend({
                 core: {
                     multiple: false,
                     themes: {
-                        icons: false,
+                        icons: true,
                         dots: false,
                     },
                     data: treeData,
@@ -188,6 +188,7 @@ BR.LayersTab = BR.ControlLayers.extend({
         function createRootNode(name) {
             var rootNode = {
                 text: i18next.t('sidebar.layers.category.' + name, name),
+                icon: false,
                 state: {
                     disabled: true,
                 },
@@ -218,6 +219,7 @@ BR.LayersTab = BR.ControlLayers.extend({
                 childNode = {
                     id: id,
                     text: getText(props, parent),
+                    icon: self.layersConfig.getOverpassIconUrl(props.icon) || false,
                     state: {
                         checked: self.layersConfig.isDefaultLayer(id, props.overlay),
                     },

--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -144,7 +144,7 @@ BR.confLayers.tree = {
                 'convenience',
                 'greengrocer',
                 'health_food',
-                'ice_cream',
+                'ice_cream_shop',
                 'organic',
             ]
         },

--- a/layers/overpass/shop/food/ice_cream_shop.geojson
+++ b/layers/overpass/shop/food/ice_cream_shop.geojson
@@ -2,7 +2,7 @@
   "geometry": null,
   "properties": {
     "name": "Ice cream",
-    "id": "ice_cream",
+    "id": "ice_cream_shop",
     "overlay": true,
     "dataSource": "OverpassAPI",
     "icon": "fas-ice-cream",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ],
     "dependencies": {
         "@bagage/leaflet.restoreview": "1.0.1",
+        "@fortawesome/fontawesome-free": "^5.15.3",
         "@ideditor/temaki": "^5.0.0",
         "@mapbox/maki": "^6.2.0",
         "@mapbox/polyline": "^0.2.0",
@@ -338,6 +339,21 @@
                 "icons/museum.svg",
                 "icons/spotting_scope.svg",
                 "icons/cabin.svg"
+            ]
+        },
+        "@fortawesome/fontawesome-free": {
+            "main": [
+                "svgs/solid/shopping-basket.svg",
+                "svgs/solid/ice-cream.svg",
+                "svgs/solid/carrot.svg",
+                "svgs/solid/cheese.svg",
+                "svgs/solid/concierge-bell.svg",
+                "svgs/solid/motorcycle.svg",
+                "svgs/solid/charging-station.svg",
+                "svgs/solid/box.svg",
+                "svgs/solid/taxi.svg",
+                "svgs/solid/phone-alt.svg",
+                "svgs/solid/beer.svg"
             ]
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-free@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz#c36ffa64a2a239bf948541a97b6ae8d729e09a9a"
+  integrity sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w==
+
 "@gulp-sourcemaps/identity-map@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz#a6e8b1abec8f790ec6be2b8c500e6e68037c0019"


### PR DESCRIPTION
Extends #397 to include referenced `fas-` icons from Font Awesome 5 as SVG images.

I currently don't want to deal with upgrading Font Awesome to version 5 (or switching to an alternative icon set). So this is just copying the referenced icons as plain SVG files and not including anything else to avoid conflicts with the currently used version 4.7.

Also shows all icons in the layer tree (loaded individually for now).
