### PR TITLE
Feature/add overpass poi layer supermarket

### DIFF
--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -146,6 +146,7 @@ BR.confLayers.tree = {
                 'health_food',
                 'ice_cream_shop',
                 'organic',
+                'supermarket',
             ]
         },
         'tourism': [

--- a/layers/overpass/shop/food/supermarket.geojson
+++ b/layers/overpass/shop/food/supermarket.geojson
@@ -5,7 +5,7 @@
         "id": "supermarket",
         "overlay": true,
         "dataSource": "OverpassAPI",
-        "icon": "fas-shopping-basket",
+        "icon": "fas-shopping-cart",
         "query": "nwr[shop=supermarket];"
     },
     "type": "Feature"

--- a/layers/overpass/shop/food/supermarket.geojson
+++ b/layers/overpass/shop/food/supermarket.geojson
@@ -1,0 +1,12 @@
+{
+    "geometry": null,
+    "properties": {
+        "name": "Supermarket",
+        "id": "supermarket",
+        "overlay": true,
+        "dataSource": "OverpassAPI",
+        "icon": "fas-shopping-basket",
+        "query": "nwr[shop=supermarket];"
+    },
+    "type": "Feature"
+}

--- a/package.json
+++ b/package.json
@@ -351,6 +351,7 @@
         "@fortawesome/fontawesome-free": {
             "main": [
                 "svgs/solid/shopping-basket.svg",
+                "svgs/solid/shopping-cart.svg",
                 "svgs/solid/ice-cream.svg",
                 "svgs/solid/carrot.svg",
                 "svgs/solid/cheese.svg",


### PR DESCRIPTION
This pull request adds an Overpass API POI layer for the OSM tag `supermarket`. 

The `fas-shopping-cart` icon is added from FontAwesome Free (license for FontAwesome was already mentioned in README).