### PR TITLE
Add SwissTopo tile layers

### DIFF
--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -78,6 +78,8 @@ BR.LayersConfig = L.Class.extend({
         BR.layerIndex['1069'].geometry = BR.confLayers.europeGeofabrik;
 
         BR.layerIndex['OpenStreetMap.CH'].geometry = BR.confLayers.switzerlandPadded;
+        BR.layerIndex['swisstopo-landeskarte'].geometry = BR.confLayers.switzerlandPadded;
+        BR.layerIndex['swisstopo-aerial'].geometry = BR.confLayers.switzerlandPadded;
 
         BR.layerIndex['1017'].geometry = BR.confLayers.osmapaPl;
     },

--- a/layers/config/overrides.js
+++ b/layers/config/overrides.js
@@ -137,6 +137,14 @@ BR.confLayers.getPropertyOverrides = function() {
             'mapUrl': 'https://osm.ch/#{zoom}/{lat}/{lon}',
             'worldTiles': true
         },
+        'swisstopo-landeskarte': {
+            'country_code': 'CH',
+            'mapUrl': 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/{z}/{x}/{y}.jpeg',
+        },
+        'swisstopo-aerial': {
+            'country_code': 'CH',
+            'mapUrl': 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg',
+        },
         'topplus-open': {
             'country_code': 'DE',
             'mapUrl': 'http://www.geodatenzentrum.de/geodaten/gdz_rahmen.gdz_div?gdz_spr=deu&gdz_user_id=0&gdz_akt_zeile=5&gdz_anz_zeile=1&gdz_unt_zeile=41',

--- a/layers/config/overrides.js
+++ b/layers/config/overrides.js
@@ -139,11 +139,11 @@ BR.confLayers.getPropertyOverrides = function() {
         },
         'swisstopo-landeskarte': {
             'country_code': 'CH',
-            'mapUrl': 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/{z}/{x}/{y}.jpeg',
+            'mapUrl': 'https://map.geo.admin.ch/?swisssearch={lat},{lon}',
         },
         'swisstopo-aerial': {
             'country_code': 'CH',
-            'mapUrl': 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg',
+            'mapUrl': 'https://map.geo.admin.ch/?swisssearch={lat},{lon}',
         },
         'topplus-open': {
             'country_code': 'DE',

--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -39,7 +39,13 @@ BR.confLayers.tree = {
                     'osmbe-nl',
                 ]
             },
-            'OpenStreetMap.CH',
+            {
+                'CH': [
+                    'OpenStreetMap.CH',
+                    'swisstopo-landeskarte',
+                    'swisstopo-aerial',
+                ]
+            },
             'topplus-open',
             {
                 'IL': [

--- a/layers/extra/swisstopo-aerial.geojson
+++ b/layers/extra/swisstopo-aerial.geojson
@@ -1,0 +1,17 @@
+{
+    "geometry": null,
+    "properties": {
+        "attribution": {
+            "html": "© <a href='https://www.swisstopo.ch/' target='_blank'>Swisstopo</a>"
+        },
+        "id": "swisstopo-aerial",
+        "max_zoom": 28,
+        "name": "Swisstopo Aerial Photographs",
+        "type": "tms",
+        "url": "https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg",
+        "layers": "web",
+        "format": "image/jpeg"
+    },
+    "type": "Feature"
+}
+  

--- a/layers/extra/swisstopo-landeskarte.geojson
+++ b/layers/extra/swisstopo-landeskarte.geojson
@@ -1,0 +1,17 @@
+{
+    "geometry": null,
+    "properties": {
+        "attribution": {
+            "html": "© <a href='https://www.swisstopo.ch/' target='_blank'>Swisstopo</a>"
+        },
+        "id": "swisstopo",
+        "max_zoom": 28,
+        "name": "Swisstopo Landeskarte",
+        "type": "tms",
+        "url": "https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/{z}/{x}/{y}.jpeg",
+        "layers": "web",
+        "format": "image/jpeg"
+    },
+    "type": "Feature"
+}
+  


### PR DESCRIPTION
This PR adds two Swiss tile maps from Swisstopo (the official Swiss street map and aerial photographs). Both maps are freely available since March 2021 and can be retrieved directly from Swisstopo servers.

It has been suggested to add them to the standard map set in #402.

![image](https://user-images.githubusercontent.com/1394828/119275070-4ef4d200-bc13-11eb-9f25-88fbd628791f.png)
![image](https://user-images.githubusercontent.com/1394828/119275081-5c11c100-bc13-11eb-9715-1a6be2a17821.png)