### PR TITLE
Normalize `surface` and `smoothness` variants

### DIFF
--- a/js/control/TrackAnalysis.js
+++ b/js/control/TrackAnalysis.js
@@ -500,20 +500,29 @@ BR.TrackAnalysis = L.Class.extend({
 
                 return parsed.highway === dataName;
             case 'surface':
-                if (dataName === 'internal-unknown' && typeof parsed.surface !== 'string') {
-                    return true;
-                }
-
-                return typeof parsed.surface === 'string' && parsed.surface === dataName;
+                return this.singleWayTagMatchesData('surface', parsed, dataName);
             case 'smoothness':
-                if (dataName === 'internal-unknown' && typeof parsed.smoothness !== 'string') {
-                    return true;
-                }
-
-                return typeof parsed.smoothness === 'string' && parsed.smoothness === dataName;
+                return this.singleWayTagMatchesData('smoothness', parsed, dataName);
         }
 
         return false;
+    },
+
+    singleWayTagMatchesData: function (category, parsedData, lookupValue) {
+        var foundValue = null;
+
+        for (var iterationKey in parsedData) {
+            if (iterationKey.indexOf(category) !== -1) {
+                foundValue = parsedData[iterationKey];
+                break;
+            }
+        }
+
+        if (lookupValue === 'internal-unknown' && foundValue === null) {
+            return true;
+        }
+
+        return foundValue === lookupValue;
     },
 
     /**


### PR DESCRIPTION
The `surface` tag exists in different variants,
e.g. `surface`, `cycleway:surface` etc.

Previously, the `surface` and `smoothness` tags were only processed for route analysis if they were found in their canonical form in the BRouter server response.

With this commit, the variants are normalized down to the main tag name which has the effect that they're included in the route analysis.

Fixes #438