### PR TITLE
Toggle "locate" state with keyboard shortcut

### DIFF
--- a/js/Map.js
+++ b/js/Map.js
@@ -120,6 +120,10 @@ BR.Map = {
                 'keydown',
                 function (e) {
                     if (BR.Util.keyboardShortcutsAllowed(e) && e.keyCode === this.options.shortcut.locate) {
+                        if (locationControl._active) {
+                            locationControl.stop();
+                            return;
+                        }
                         locationControl.start();
                     }
                 },


### PR DESCRIPTION
Pressing `L` now toggles between states *active* and *inactive* for the “locate me” feature.

Until now, the feature could only be activated via keyboard, but not deactivated.