### PR TITLE
fix swisstopo-landeskarte id

### DIFF
--- a/layers/extra/swisstopo-landeskarte.geojson
+++ b/layers/extra/swisstopo-landeskarte.geojson
@@ -4,7 +4,7 @@
         "attribution": {
             "html": "© <a href='https://www.swisstopo.ch/' target='_blank'>Swisstopo</a>"
         },
-        "id": "swisstopo",
+        "id": "swisstopo-landeskarte",
         "max_zoom": 28,
         "name": "Swisstopo Landeskarte",
         "type": "tms",


### PR DESCRIPTION
Hi,

There is a typo in the id of the swisstopo-landeskarte layer added in PR #422 and it leads to behaviors like not being able to remove the layer once added to baselayers.

(Tell me if you'd rather me have open an issue first)