### PR TITLE
Fix default profile not selected with hash

### DIFF
--- a/js/control/RoutingOptions.js
+++ b/js/control/RoutingOptions.js
@@ -18,7 +18,8 @@ BR.RoutingOptions = L.Evented.extend({
             var option = document.createElement('option');
             option.value = profiles[i];
             option.text = i18next.t('navbar.profile.' + profiles[i]);
-            if (remembered_profile !== null && remembered_profile === profiles[i]) {
+            // set remembered profile, only when no URL hash (assumes fullHash plugin not initialised yet)
+            if (!location.hash && remembered_profile !== null && remembered_profile === profiles[i]) {
                 option.selected = true;
                 remembered_profile_was_selected = true;
             }

--- a/tests/control/RoutingOptions.test.js
+++ b/tests/control/RoutingOptions.test.js
@@ -1,0 +1,63 @@
+BR = {};
+$ = require('jquery');
+i18next = require('i18next');
+require('bootstrap');
+require('bootstrap-select');
+require('leaflet');
+
+require('../../config.js');
+require('../../js/Util.js');
+require('../../js/router/BRouter.js');
+require('../../js/control/RoutingOptions.js');
+
+const fs = require('fs');
+const indexHtmlString = fs.readFileSync('index.html', 'utf8');
+const indexHtml = new DOMParser().parseFromString(indexHtmlString, 'text/html');
+
+let defaultProfile;
+
+beforeEach(() => {
+    document.body = indexHtml.body.cloneNode(true);
+    location.hash = '';
+    // as used in BRouter.getUrlParams
+    defaultProfile = BR.conf.profiles[0];
+});
+
+describe('Profile selection', () => {
+    test('sets default profile (trekking) when no hash and no localStorage entry', () => {
+        let routingOptions = new BR.RoutingOptions();
+        routingOptions.setOptions({});
+        const profile = routingOptions.getOptions().profile;
+        expect(profile).toEqual(defaultProfile);
+    });
+
+    // defaults are not set in hash, see BRouter.getUrlParams
+    test('sets default profile (trekking) when hash without `profile` param regardless of localStorage', () => {
+        location.hash = '#map=5/50.986/9.822/standard';
+        localStorage.routingprofile = 'shortest';
+
+        let routingOptions = new BR.RoutingOptions();
+        routingOptions.setOptions({});
+        const profile = routingOptions.getOptions().profile;
+        expect(profile).toEqual(defaultProfile);
+    });
+
+    test('sets profile from hash', () => {
+        location.hash = '#map=5/50.986/9.822/standard&profile=fastbike';
+        localStorage.routingprofile = 'shortest';
+
+        let routingOptions = new BR.RoutingOptions();
+        routingOptions.setOptions({ profile: 'fastbike' });
+        const profile = routingOptions.getOptions().profile;
+        expect(profile).toEqual('fastbike');
+    });
+
+    test('sets profile from localStorage when no hash', () => {
+        localStorage.routingprofile = 'shortest';
+
+        let routingOptions = new BR.RoutingOptions();
+        routingOptions.setOptions({});
+        const profile = routingOptions.getOptions().profile;
+        expect(profile).toEqual('shortest');
+    });
+});

--- a/tests/control/RoutingOptions.test.js
+++ b/tests/control/RoutingOptions.test.js
@@ -5,7 +5,7 @@ require('bootstrap');
 require('bootstrap-select');
 require('leaflet');
 
-require('../../config.js');
+require('../../config.template.js');
 require('../../js/Util.js');
 require('../../js/router/BRouter.js');
 require('../../js/control/RoutingOptions.js');


### PR DESCRIPTION
An URL with hash, but no explicit `profile` parameter, should always select the default profile ("trekking"), e.g.:
http://localhost:3000/#map=5/50.986/9.822/standard

as default values are not explicitly set in the URL (or rather removed):
https://github.com/nrenner/brouter-web/blob/fcdfe49034b787282d08539a0a2090f1882ad880/js/router/BRouter.js#L64-L65

But currently, if you had selected a different profile before, this is remembered from `localStorage` and set instead (introduced in #456).

Review welcome (cc @mjaschen, @bagage).