### PR TITLE
Improves rendering of Overpass data; add OSM link to Overpass popups

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -50,8 +50,46 @@ table.dataTable {
     font-size: 1.2rem;
 }
 
-.overpass-tags th {
+.overpass-tags th,
+.overpass-tags td {
+    padding: 0.25em 0.5em;
     vertical-align: top;
+}
+
+.overpass-tags thead {
+    text-transform: uppercase;
+    color: #666;
+}
+
+.overpass-tags thead tr {
+    background-color: #ddd;
+}
+
+.overpass-tags thead th.overpass-label-key {
+    text-align: right;
+}
+
+.overpass-tags tbody tr:nth-child(even) {
+    background-color: #eee;
+}
+
+.overpass-tags tbody tr:last-child {
+    border-bottom: 1px solid #eee;
+}
+
+.overpass-tags tbody th {
+    text-align: right;
+    font-weight: normal;
+}
+
+.overpass-osm-link {
+    margin-top: 0.5rem;
+    text-align: right;
+    font-size: 80%;
+}
+.overpass-osm-link::before {
+    content: '🔎';
+    margin-right: 0.25em;
 }
 
 .overpass-layer-icon .sign > * {

--- a/locales/en.json
+++ b/locales/en.json
@@ -81,6 +81,10 @@
     "customize": "Customize layers",
     "opacity-slider": "Opacity slider",
     "overpass-loading-indicator": "Running Overpass API query ...",
+    "overpass-table-key": "Key",
+    "overpass-table-value": "Value",
+    "overpass-inspect-at-openstreetmap": "Inspect Object at OpenStreetMap",
+    "overpass-osm": "OSM",
     "remove-selection": "Remove selection"
   },
   "loadNogos": {


### PR DESCRIPTION
(see #467)

- add some styling to the Overpass data table (alternating row colors; text alignment)
- add link to OSM object below the Overpass data table
- add 4 new entries in `en.json`