### PR TITLE
Feature Request: Road surface as quality color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -567,6 +567,7 @@ table.dataTable thead .sorting {
 
 table.track-analysis-table tbody tr:hover,
 table.dataTable.hover tbody tr:hover,
+table.dataTable.hover tbody tr.hoverRoute,
 table.dataTable.display tbody tr:hover {
     background-color: rgba(255, 255, 0, 0.3);
 }

--- a/js/index.js
+++ b/js/index.js
@@ -36,7 +36,6 @@
             pois,
             circlego,
             urlHash;
-
         // By default bootstrap-select use glyphicons
         $('.selectpicker').selectpicker({
             iconBase: 'fa',
@@ -223,9 +222,10 @@
 
         function requestUpdate(updatable) {
             var track = routing.toPolyline(),
-                segments = routing.getSegments();
+                segments = routing.getSegments(),
+                segmentsLayer = routing._segments;
 
-            updatable.update(track, segments);
+            updatable.update(track, segments, segmentsLayer);
         }
 
         routingOptions = new BR.RoutingOptions();
@@ -342,7 +342,7 @@
             } else {
                 stats.update(track, segments);
             }
-            trackMessages.update(track, segments);
+            trackMessages.update(track, segments, segmentsLayer);
             trackAnalysis.update(track, segments);
 
             exportRoute.update(latLngs, segments);

--- a/js/plugin/RoutingPathQuality.js
+++ b/js/plugin/RoutingPathQuality.js
@@ -68,8 +68,9 @@ BR.RoutingPathQuality = L.Control.extend({
                         renderer: renderer,
                         palette: {
                             // normal range
-                            0.0: '#ff0000',
-                            0.95: '#00ff00',
+                            0.0: 'red',
+                            0.45: 'yellow',
+                            0.9: 'green',
                             // special value for unknown
                             1.0: '#888888',
                         },
@@ -92,6 +93,7 @@ BR.RoutingPathQuality = L.Control.extend({
                             let surface = null;
                             switch (data.get('surface')) {
                                 case 'paved':
+                                case 'chipseal':
                                     surface = 0.8;
                                     break;
                                 case 'asphalt':
@@ -104,6 +106,7 @@ BR.RoutingPathQuality = L.Control.extend({
                                 case 'sett':
                                 case 'gravel':
                                 case 'pebblestone':
+                                case 'unpaved':
                                     surface = 0.5;
                                     break;
                                 case 'paving_stones':
@@ -129,9 +132,9 @@ BR.RoutingPathQuality = L.Control.extend({
                                     break;
                                 case null:
                                     break;
-                                default:
+                                /*default:
                                     console.warn('unhandled surface type', data.get('surface'));
-                                    break;
+                                    break;*/
                             }
 
                             // modifier tracktype; also sometimes only tracktype is available
@@ -141,8 +144,8 @@ BR.RoutingPathQuality = L.Control.extend({
                                         if (surface === null) {
                                             surface = 0.9;
                                         } /* else {
-					    don't change
-					} */
+                                            don't change
+                                        } */
                                         break;
                                     case 'grade2':
                                         if (surface === null) {
@@ -179,10 +182,10 @@ BR.RoutingPathQuality = L.Control.extend({
                                 // modifier for surface quality
                                 switch (data.get('smoothness')) {
                                     case 'excellent':
-                                        surface = Math.max(surface * 1.1, 1.0);
+                                        surface = Math.min(surface * 1.1, 1.0);
                                         break;
                                     case 'good':
-                                        surface = Math.max(surface * 1.05, 1.0);
+                                        surface = Math.min(surface * 1.05, 1.0);
                                         break;
                                     case 'intermediate':
                                         surface *= 0.9;

--- a/locales/en.json
+++ b/locales/en.json
@@ -164,6 +164,7 @@
     "route-quality-altitude": "Altitude coding",
     "route-quality-cost": "Cost coding",
     "route-quality-incline": "Incline coding",
+    "route-quality-surface": "Road surface/quality",
     "route-quality-shortcut": "{{action}} ({{key}} key to toggle)",
     "route-tooltip-segment": "Drag to create a new waypoint. Click to toggle straight line.",
     "route-tooltip-waypoint": "Waypoint. Drag to move; Click to remove.",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "leaflet-editable": "1.2.0",
         "leaflet-filelayer": "1.2.0",
         "leaflet-geometryutil": "0.10.1",
-        "leaflet-hotline": "0.4.0",
+        "leaflet-hotline": "tbsmark86/Leaflet.hotline#25b2457",
         "leaflet-osm-notes": "osmlab/leaflet-osm-notes#af2aa811",
         "leaflet-plugins": "3.4.0",
         "leaflet-providers": "1.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8340,10 +8340,9 @@ leaflet-geometryutil@0.10.1:
   dependencies:
     leaflet "^1.6.0"
 
-leaflet-hotline@0.4.0:
+leaflet-hotline@tbsmark86/Leaflet.hotline#25b2457:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/leaflet-hotline/-/leaflet-hotline-0.4.0.tgz#e01069836a9d2e2c78b1fa1db2013bd03c8ff8d9"
-  integrity sha512-+In6c8WxMsRKMmwQ1m2GmbNxbXvA3WsrOilJGK7l4Sj+mUDh1gdyGMYCIoRBtUeX7lMvBc4KKeEVAlwQERKpxg==
+  resolved "https://codeload.github.com/tbsmark86/Leaflet.hotline/tar.gz/25b24572b99ac66203d857e0fb27f430e2f68448"
 
 leaflet-osm-notes@osmlab/leaflet-osm-notes#af2aa811:
   version "0.0.1"


### PR DESCRIPTION
This is similar to #310

Of course the actual numbers used are highly subjective.

Notes:
* Required fork of leaflet-hotline with a new option to disable the gradient display.
  This is was done so that short stretches of very bad surface adjacent to very good ones are visible.
  (The original author does not maintain it anymore so no harm in forking.)
* I've ignored the compat warning:
    URLSearchParams is not supported in Safari 7, op_mini all, IE 10, android 4.1
   don't seem relevant today. Those are all EOL maybe eslint configuration should be updated?
   And supporting opera-mini seems pointless.