### PR TITLE
Add IGNF Scan25 baselayer (requires key)

### DIFF
--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -89,6 +89,7 @@ BR.LayersConfig = L.Class.extend({
 
         BR.layerIndex['ignf-aerial'].geometry = BR.confLayers.franceBbox;
         BR.layerIndex['ignf-map'].geometry = BR.confLayers.franceBbox;
+        BR.layerIndex['ignf-scan25'].geometry = BR.confLayers.franceBbox;
     },
 
     _addLanguageDefaultLayer: function () {

--- a/keys.template.js
+++ b/keys.template.js
@@ -19,5 +19,8 @@
 
         // Mapillary, https://www.mapillary.com/dashboard/developers
         mapillary: ``,
+
+        // IGN France (for Scan25 base layer), https://geoservices.ign.fr/services-web-issus-des-scans-ign
+        ignf: '',
     };
 })();

--- a/layers/config/overrides.js
+++ b/layers/config/overrides.js
@@ -160,6 +160,10 @@ BR.confLayers.getPropertyOverrides = function() {
             'mapUrl': 'https://www.geoportail.gouv.fr/carte?c={lon},{lat}&z={zoom}&l0=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2::GEOPORTAIL:OGC:WMTS(1)&permalink=yes',
             'worldTiles': true // -z7
         },
+        'ignf-scan25': {
+            'country_code': 'FR',
+            'mapUrl': 'https://www.geoportail.gouv.fr/carte?c={lon},{lat}&z={zoom}&l0=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR::GEOPORTAIL:OGC:WMTS(1)&permalink=yes',
+        },
         'OpenStreetMap-turistautak': {
             'nameShort': 'OSM Turistautak',
             'mapUrl': 'https://turistautak.openstreetmap.hu/?zoom={zoom}&lat={lat}&lon={lon}&layers=0B00F'

--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -51,6 +51,7 @@ BR.confLayers.tree = {
                 'FR': [
                     'ignf-aerial',
                     'ignf-map',
+                    'ignf-scan25',
                 ]
             },
             {

--- a/layers/extra/ignf-scan25.geojson
+++ b/layers/extra/ignf-scan25.geojson
@@ -1,0 +1,15 @@
+{
+    "geometry": null,
+    "properties": {
+        "attribution": {
+            "html": "© <a href='https://www.ign.fr/' target='_blank'>IGN</a>"
+        },
+        "id": "ignf-scan25",
+        "max_zoom": 21,
+        "name": "IGN France - Carte topographique (Scan25)",
+        "type": "tms",
+        "url": "https://wxs.ign.fr/{keys_ignf}/geoportail/wmts?LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR&EXCEPTIONS=text/xml&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+    },
+    "type": "Feature"
+}
+  


### PR DESCRIPTION
Adds the IGN France - Carte topographique (Scan25) base layer.

This layer requires a valid key for "ignf" (see key.template.js in the root directory)

Key can be generated by:
* creating an account on https://geoservices.ign.fr/ (website is entirely in french)
* once logged in, visit "Mon Espace" > "Mes clés de service web" (https://geoservices.ign.fr/mes-cles)
* choose "Créer une clé"
* choose the first license "Usage gratuit" (free use)
* copy and use your new key
* optionally (recommended in production), add a referer safety on your key, so that only your website can send requests using it.

----

Related issue : #463 