### PR TITLE
Turn instructions had wrong distance when using multiple segments

### DIFF
--- a/tests/control/Export.test.js
+++ b/tests/control/Export.test.js
@@ -18,6 +18,11 @@ const indexHtml = new DOMParser().parseFromString(indexHtmlString, 'text/html');
 const segments = require('./data/segments.json');
 const brouterTotal = require('./data/brouterTotal.json');
 
+// fix turn instruction distance
+// This is buggy on the backend when request a route with a waypoint
+brouterTotal.features[0].properties.voicehints[0][3] += 53;
+brouterTotal.features[0].properties.voicehints[2][3] += 49;
+
 // resolve intended/accepted differences before comparing
 function adopt(total, brouterTotal) {
     // BRouter total aggregates messages over segments, client total does not,
@@ -64,6 +69,17 @@ test('total track', () => {
     total = BR.Export._concatTotalTrack(segments);
     adopt(total, brouterTotal);
     expect(total).toEqual(brouterTotal);
+});
+
+test('hint distance fix', () => {
+    const segmentsCopy = JSON.parse(JSON.stringify(segments, null, 2));
+
+    // general case already tested
+
+    // special case: second segment without hint
+    segmentsCopy[1].feature.properties.voicehints = null;
+    let total = BR.Export._concatTotalTrack(segmentsCopy);
+    expect(total.features[0].properties.voicehints[0][3]).toEqual(299);
 });
 
 test('include route points', () => {

--- a/tests/control/data/brouterTotal.json
+++ b/tests/control/data/brouterTotal.json
@@ -1,45 +1,46 @@
 {
-    "type": "FeatureCollection",
-    "features": [
-      {
-        "type": "Feature",
-        "properties": {
-          "creator": "BRouter-1.1",
-          "name": "brouter_1615489279610_0",
-          "track-length": "388",
-          "filtered ascend": "1",
-          "plain-ascend": "0",
-          "total-time": "44",
-          "total-energy": "4420",
-          "cost": "703",
-          "voicehints": [
-            [1,5,0,88.0,89],
-            [6,2,0,99.0,-90],
-            [7,2,0,10.0,-90]
-          ],
-          "messages": [
-            ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags"],
-            ["8468340", "49488794", "101", "89", "1000", "0", "0", "0", "0", "highway=residential surface=asphalt cycleway=lane oneway=yes lcn=yes smoothness=good route_bicycle_icn=yes route_bicycle_ncn=yes route_bicycle_rcn=yes", ""],
-            ["8469852", "49489230", "100", "299", "1150", "0", "270", "0", "0", "highway=residential surface=asphalt oneway=yes smoothness=good", ""]
-          ],
-          "times": [0,9.592,12.271,14.13,19.406,22.134,28.833,37.817,38.938,44.217]
-        },
-        "geometry": {
-          "type": "LineString",
-          "coordinates": [
-            [8.467714, 49.488115, 101.5],
-            [8.468340, 49.488794, 101.5],
-            [8.468586, 49.488698, 101.5],
-            [8.468743, 49.488636, 101.5],
-            [8.469161, 49.488473, 101.75],
-            [8.469355, 49.488395, 102.0],
-            [8.469971, 49.488151, 103.5],
-            [8.470671, 49.488909, 99.5],
-            [8.470561, 49.488951, 99.5],
-            [8.469984, 49.489178, 100.0]
-          ]
-        }
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "creator": "BRouter-1.7.0",
+        "name": "brouter_trekking_0",
+        "track-length": "382",
+        "filtered ascend": "2",
+        "plain-ascend": "-1",
+        "total-time": "68",
+        "total-energy": "6837",
+        "cost": "696",
+        "voicehints": [
+          [1,5,0,138.0,89],
+          [6,2,0,98.0,-90],
+          [7,2,0,58.0,-90]
+        ],
+        "messages": [
+          ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags", "Time", "Energy"],
+          ["8468340", "49488794", "101", "88", "1000", "0", "0", "0", "0", "highway=residential surface=asphalt oneway=yes lcn=yes cycleway:right=lane cycleway:left=no smoothness=good route_bicycle_icn=yes route_bicycle_rcn=yes", "", "14", "1478"],
+          ["8469971", "49488151", "103", "138", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes oneway:bicycle=no smoothness=good", "", "42", "4202"],
+          ["8470671", "49488909", "99", "98", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes smoothness=good", "", "58", "5818"],
+          ["8469935", "49489198", "100", "58", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes oneway:bicycle=no smoothness=good", "", "68", "6837"]
+        ],
+        "times": [0,14.784,18.312,20.496,26.725,29.906,42.02,58.183,59.679,68.367]
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [8.467714, 49.488114, 101.5],
+          [8.468340, 49.488794, 101.5],
+          [8.468586, 49.488698, 101.5],
+          [8.468743, 49.488636, 101.5],
+          [8.469161, 49.488473, 101.75],
+          [8.469355, 49.488395, 103.5],
+          [8.469971, 49.488151, 103.5],
+          [8.470671, 49.488909, 99.5],
+          [8.470561, 49.488951, 100.0],
+          [8.469984, 49.489178, 100.0]
+        ]
       }
-    ]
-  }
-  
+    }
+  ]
+}

--- a/tests/control/data/segments.json
+++ b/tests/control/data/segments.json
@@ -1,97 +1,98 @@
 [{
-    "feature": {
-            "type": "Feature",
-            "properties": {
-              "creator": "BRouter-1.1",
-              "name": "brouter_1615393581719_0",
-              "track-length": "177",
-              "filtered ascend": "0",
-              "plain-ascend": "1",
-              "total-time": "22",
-              "total-energy": "2213",
-              "cost": "280",
-              "voicehints": [
-                [1,5,0,88.0,89]
-              ],
-              "messages": [
-                ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags"],
-                ["8468340", "49488794", "101", "89", "1000", "0", "0", "0", "0", "highway=residential surface=asphalt cycleway=lane oneway=yes lcn=yes smoothness=good route_bicycle_icn=yes route_bicycle_ncn=yes route_bicycle_rcn=yes", ""],
-                ["8469971", "49488151", "102", "88", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes smoothness=good", ""]
-              ],
-              "times": [0,9.592,12.271,14.13,19.406,22.134]
-            },
-            "geometry": {
-              "type": "LineString",
-              "coordinates": [
-                [8.467714, 49.488115, 101.5],
-                [8.468340, 49.488794, 101.5],
-                [8.468586, 49.488698, 101.5],
-                [8.468743, 49.488636, 101.5],
-                [8.469161, 49.488473, 101.75],
-                [8.469355, 49.488395, 102.0]
-              ]
-            }
+  "feature": {
+      "type": "Feature",
+      "properties": {
+        "creator": "BRouter-1.7.0",
+        "name": "brouter_trekking_0",
+        "track-length": "174",
+        "filtered ascend": "2",
+        "plain-ascend": "2",
+        "total-time": "30",
+        "total-energy": "2990",
+        "cost": "277",
+        "voicehints": [
+          [1,5,0,86.0,89]
+        ],
+        "messages": [
+          ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags", "Time", "Energy"],
+          ["8468340", "49488794", "101", "88", "1000", "0", "0", "0", "0", "highway=residential surface=asphalt oneway=yes lcn=yes cycleway:right=lane cycleway:left=no smoothness=good route_bicycle_icn=yes route_bicycle_rcn=yes", "", "14", "1478"],
+          ["8469971", "49488151", "103", "86", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes oneway:bicycle=no smoothness=good", "", "29", "2990"]
+        ],
+        "times": [0,14.784,18.312,20.496,26.725,29.906]
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [8.467714, 49.488114, 101.5],
+          [8.468340, 49.488794, 101.5],
+          [8.468586, 49.488698, 101.5],
+          [8.468743, 49.488636, 101.5],
+          [8.469161, 49.488473, 101.75],
+          [8.469355, 49.488395, 103.5]
+        ]
+      }
     }
 },
 {
-    "feature": {
-            "type": "Feature",
-            "properties": {
-              "creator": "BRouter-1.1",
-              "name": "brouter_1615393581719_0",
-              "track-length": "162",
-              "filtered ascend": "1",
-              "plain-ascend": "-2",
-              "total-time": "17",
-              "total-energy": "1680",
-              "cost": "367",
-              "voicehints": [
-                [1,2,0,99.0,-90],
-                [2,2,0,10.0,-90]
-              ],
-              "messages": [
-                ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags"],
-                ["8469852", "49489230", "99", "162", "1150", "0", "180", "0", "0", "highway=residential surface=asphalt oneway=yes smoothness=good", ""]
-              ],
-              "times": [0,6.698,15.683,16.804]
-            },
-            "geometry": {
-              "type": "LineString",
-              "coordinates": [
-                [8.469355, 49.488395, 102.0],
-                [8.469971, 49.488151, 103.5],
-                [8.470671, 49.488909, 99.5],
-                [8.470561, 49.488951, 99.5]
-              ]
-            }
+  "feature": {
+      "type": "Feature",
+      "properties": {
+        "creator": "BRouter-1.7.0",
+        "name": "brouter_trekking_0",
+        "track-length": "159",
+        "filtered ascend": "1",
+        "plain-ascend": "-1",
+        "total-time": "30",
+        "total-energy": "2977",
+        "cost": "363",
+        "voicehints": [
+          [1,2,0,98.0,-90],
+          [2,2,0,9.0,-90]
+        ],
+        "messages": [
+          ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags", "Time", "Energy"],
+          ["8469971", "49488151", "103", "52", "1150", "0", "0", "0", "0", "highway=residential surface=asphalt oneway=yes oneway:bicycle=no smoothness=good", "", "12", "1211"],
+          ["8470671", "49488909", "99", "98", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes smoothness=good", "", "28", "2827"],
+          ["8469935", "49489198", "100", "9", "1150", "0", "90", "0", "0", "highway=residential surface=asphalt oneway=yes oneway:bicycle=no smoothness=good", "", "29", "2977"]
+        ],
+        "times": [0,12.114,28.276,29.773]
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [8.469355, 49.488395, 102.0],
+          [8.469971, 49.488151, 103.5],
+          [8.470671, 49.488909, 99.5],
+          [8.470561, 49.488951, 100.0]
+        ]
+      }
     }
-      
 },
 {
-    "feature": {
-            "type": "Feature",
-            "properties": {
-              "creator": "BRouter-1.1",
-              "name": "brouter_1615393581719_0",
-              "track-length": "49",
-              "filtered ascend": "0",
-              "plain-ascend": "1",
-              "total-time": "5",
-              "total-energy": "527",
-              "cost": "56",
-              "messages": [
-                ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags"],
-                ["8469852", "49489230", "100", "49", "1150", "0", "0", "0", "0", "highway=residential surface=asphalt oneway=yes smoothness=good", ""]
-              ],
-              "times": [0,5.279]
-            },
-            "geometry": {
-              "type": "LineString",
-              "coordinates": [
-                [8.470561, 49.488951, 99.5],
-                [8.469984, 49.489178, 100.0]
-              ]
-            }
-          }
+  "feature": {
+      "type": "Feature",
+      "properties": {
+        "creator": "BRouter-1.7.0",
+        "name": "brouter_trekking_0",
+        "track-length": "49",
+        "filtered ascend": "0",
+        "plain-ascend": "1",
+        "total-time": "9",
+        "total-energy": "868",
+        "cost": "56",
+        "messages": [
+          ["Longitude", "Latitude", "Elevation", "Distance", "CostPerKm", "ElevCost", "TurnCost", "NodeCost", "InitialCost", "WayTags", "NodeTags", "Time", "Energy"],
+          ["8469935", "49489198", "100", "49", "1150", "0", "0", "0", "0", "highway=residential surface=asphalt oneway=yes oneway:bicycle=no smoothness=good", "", "8", "868"]
+        ],
+        "times": [0,8.688]
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [8.470561, 49.488951, 99.5],
+          [8.469984, 49.489178, 100.0]
+        ]
+      }
+    }
 }
 ]


### PR DESCRIPTION
Split of from pull-request #641 

The distance from the start for the a segment till the next turn is missing from the distance value of the last turn in the previous segment.
However it's not really that important right now because it's never visible to the user and only used when exporting to gpx in locus-style. (locus:rteDistance and locus:rteSpeed).

> Your "distance-from-last" comment got me confused,

Yeah it's all really confusing :)

I've added more explanation to the code maybe this clears it up - or make it worse.

> So voicehints of the expected test result brouterTotal.json

Ok. I've changed the test so the brouterTotal.json remains untouched.

> should match the [total download](https://brouter.de/brouter?lonlats=8.467712,49.488117%7C8.469354,49.488394%7C8.470556,49.488946%7C8.469982,49.489176&profile=trekking&alternativeidx=0&format=geojson&profile:turnInstructionMode=2) from the server (for [this route](https://brouter.de/brouter-web/#map=18/49.48856/8.46986/standard&lonlats=8.467712,49.488117;8.469354,49.488394;8.470556,49.488946;8.469982,49.489176)).

Ah ok. I did not know that the server could handle multiple segments. So yes you're right it's also a backend bug. Consider [this route without the first waypoint](https://brouter.de/brouter?lonlats=8.467712,49.488117%7C8.470556,49.488946%7C8.469982,49.489176&profile=trekking&alternativeidx=0&format=geojson&profile:turnInstructionMode=2):
The distance for the first turn changes from 88 to 140. That's the almost the same as my calculated value of 141.

Is this important enough to also open a bug for brouter itself?  Because unless someone is using the old export it should not affect a brouter-web user once this patch is merged?