### PR TITLE
Fix #501 missing altitude data caused js-error in leaflet-hotline

### DIFF
--- a/js/plugin/RoutingPathQuality.js
+++ b/js/plugin/RoutingPathQuality.js
@@ -40,7 +40,7 @@ BR.RoutingPathQuality = L.Control.extend({
                     valueFunction: function (latLng, prevLatLng) {
                         var deltaAltitude = latLng.alt - prevLatLng.alt, // in m
                             distance = prevLatLng.distanceTo(latLng); // in m
-                        if (distance === 0) {
+                        if (distance === 0 || isNaN(deltaAltitude)) {
                             return 0;
                         }
                         return (Math.atan(deltaAltitude / distance) * 180) / Math.PI;
@@ -56,7 +56,7 @@ BR.RoutingPathQuality = L.Control.extend({
                         renderer: renderer,
                     },
                     valueFunction: function (latLng) {
-                        return latLng.alt;
+                        return latLng.alt || 0;
                     },
                 }),
             },


### PR DESCRIPTION
Thats the simple solution. Missing values are displayed as zero altitude.

Alternate approach would be extending leaflet-hotline to not draw anything for an missing/NaN value. That shouldn't be to hard if you like it more let me know.