### PR TITLE
[WIP] [RFC] Include profile options in hash

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,6 +75,7 @@ var paths = {
             'js/Util.js',
             'js/Map.js',
             'js/LayersConfig.js',
+            'js/ProfileData.js',
             'js/router/BRouter.js',
             'js/util/*.js',
             'js/format/*.js',

--- a/js/ProfileData.js
+++ b/js/ProfileData.js
@@ -1,0 +1,153 @@
+/* Central storage for the currently selected profile.
+ *
+ * Idea is to collect all state concerning profile here without beeing tied to
+ * a specific UI element.
+ *
+ * The current profile is serialized as a profile ID or as an URL.
+ * 1) profile ID: like the profile name on the server
+ * 2) As URL "bw:<id>?opt=value": Default profile with user defined options
+ * 3) As URL "http://example.com/profile.brf?opt=value": Profile stored on external location
+ *     possibly with user defined options
+ *     TODO: NYI
+ * 4) As URL "bwl:local": Marks a manually user edited profile.
+ *     The last state of this is stored an can be accessed again
+ *     TODO: NYI
+ */
+BR.ProfileData = L.Evented.extend({
+    // Currently active profile name/id for backend Request
+    // Possible values:
+    // - any known profile name for backend
+    // - L.BRouter.CUSTOM_PREFIX - not-yet-uploaded custom profile
+    // - L.BRouter.CUSTOM_PREFIX+_1234 - uploaded custom profile
+    id: '',
+    // Original profile name/id before user made custom changes
+    // Or URL of external Profile
+    baseId: '',
+    // Options the user changed in the profile (query-string)
+    options: '',
+    // Profile is unchanged
+    isDefault: false,
+    // Profile is loaded from external URL
+    isExternal: false,
+
+    // SourceCode of current profile. Private!
+    _profileText: '',
+
+    _lastInput: false,
+
+    initialize: function () {
+        this.selectProfile(null);
+    },
+
+    /** Set selected Profile */
+    selectProfile: function (input) {
+        if (this._lastInput === input) {
+            // break event loops
+            return;
+        } else if (input === null) {
+            // set default
+            input = BR.conf.profiles[0];
+        }
+        // assert input
+        if (typeof input !== 'string') {
+            throw new TypeError('Invalid argument');
+        }
+        this._lastInput = input;
+        try {
+            this._parseProfileName(input);
+        } catch (e) {
+            console.error('Invalid Profile. Reset to Default', e, input);
+            this._parseProfileName(BR.conf.profiles[0]);
+        }
+        this.fire('changed');
+    },
+
+    _parseProfileName: function (input) {
+        if (BR.conf.profilesRename?.[input]) {
+            input = BR.conf.profilesRename[input];
+        }
+        this.isDefault = BR.conf.profiles.includes(input);
+        this.isExternal = false;
+        if (this.isDefault) {
+            this.id = this.baseId = input;
+            this.options = '';
+        } else {
+            let url = new URL(input);
+
+            // split hash and url
+            this.options = url.search;
+            url.search = '';
+
+            if (url.protocol === 'bw:') {
+                // default profile with custom options
+                if (BR.conf.profiles.includes(url.pathname)) {
+                    this.baseId = url.pathname;
+                    if (this.options) {
+                        this.id = L.BRouter.CUSTOM_PREFIX;
+                    } else {
+                        this.id = this.baseId;
+                        this.isDefault = true;
+                    }
+                } else {
+                    throw new Error(`Profile ${url.pathname} not known in Config`);
+                }
+            } else {
+                // external profile
+                this.id = L.BRouter.CUSTOM_PREFIX;
+                this.baseId = url.href;
+                this.isExternal = true;
+            }
+        }
+    },
+
+    // create profile= argument for URL Hash (not yet escaped)
+    toProfileName: function () {
+        let val;
+        if (this.isDefault) {
+            val = this.id;
+        } else if (!this.isExternal) {
+            const url = new URL(`bw:${this.baseId}`);
+            url.search = this.options;
+            val = url.toString();
+        } else {
+            // External profile
+            const url = new URL(this.baseId);
+            url.search = this.options;
+            val = url.toString();
+        }
+        return val;
+    },
+
+    setCustom: function (id) {
+        if (this.id === this.baseId) {
+            this.id = id;
+            this.isDefault = false;
+        }
+    },
+
+    setOption: function (option, value) {
+        this.setCustom(L.BRouter.CUSTOM_PREFIX);
+        let tmp = new URLSearchParams(this.options); // eslint-disable-line compat/compat
+        tmp.set(option, value);
+        this.options = tmp.toString();
+    },
+
+    setOptions: function (options) {
+        for (const [option, value] of Object.entries(options)) {
+            this.setOption(option, value);
+        }
+    },
+
+    getOptions: function () {
+        let tmp = new URLSearchParams(this.options); // eslint-disable-line compat/compat
+        let res = {};
+        for (const [key, value] of tmp.entries()) {
+            res[key] = value;
+        }
+        return res;
+    },
+
+    isInitialProfile: function () {
+        return this.id === BR.conf.profiles[0];
+    },
+});

--- a/js/control/Export.js
+++ b/js/control/Export.js
@@ -7,10 +7,10 @@ BR.Export = L.Class.extend({
         },
     },
 
-    initialize: function (router, pois, profile) {
+    initialize: function (router, pois, profileEditor) {
         this.router = router;
         this.pois = pois;
-        this.profile = profile;
+        this.profileEditor = profileEditor;
         this.exportButton = $('#exportButton');
         var trackname = (this.trackname = document.getElementById('trackname'));
         this.tracknameAllowedChars = BR.conf.tracknameAllowedChars;
@@ -64,7 +64,7 @@ BR.Export = L.Class.extend({
     },
 
     _turnInstructionInfo: function () {
-        const turnInstructionMode = +this.profile.getProfileVar('turnInstructionMode');
+        const turnInstructionMode = +this.profileEditor.getProfileVar('turnInstructionMode');
         $('.format-turns-enabled')
             .prop('hidden', turnInstructionMode <= 1)
             .attr('title', i18next.t('export.turns_enabled'));
@@ -149,8 +149,8 @@ BR.Export = L.Class.extend({
         }
         switch (format) {
             case 'gpx':
-                const turnInstructionMode = +this.profile.getProfileVar('turnInstructionMode');
-                const transportMode = this.profile.getTransportMode();
+                const turnInstructionMode = +this.profileEditor.getProfileVar('turnInstructionMode');
+                const transportMode = this.profileEditor.getTransportMode();
                 return BR.Gpx.format(track, turnInstructionMode, transportMode);
             case 'kml':
                 return BR.Kml.format(track);

--- a/js/control/Profile.js
+++ b/js/control/Profile.js
@@ -1,8 +1,10 @@
 BR.Profile = L.Evented.extend({
     cache: {},
     saveWarningShown: false,
+    profileData: null,
 
-    initialize: function () {
+    initialize: function (profileData) {
+        this.profileData = profileData;
         var textArea = L.DomUtil.get('profile_upload');
         this.editor = CodeMirror.fromTextArea(textArea, {
             lineNumbers: true,
@@ -24,6 +26,10 @@ BR.Profile = L.Evented.extend({
         this.message = new BR.Message('profile_message', {
             alert: true,
         });
+
+        this.profileData.on('changed', () => {
+            this.update();
+        });
     },
 
     clear: function (evt) {
@@ -38,16 +44,25 @@ BR.Profile = L.Evented.extend({
         button.blur();
     },
 
-    update: function (options, cb) {
-        var profileName = options.profile,
+    update: function (_, cb) {
+        var profileName = this.profileData.id,
             profileUrl,
             loading = false;
+
+        var profileNameBase = profileName;
+        if (!this.profileData.isDefault) {
+            profileNameBase = this.profileData.baseId;
+        }
 
         if (profileName && BR.conf.profilesUrl) {
             this.selectedProfileName = profileName;
 
-            if (!(profileName in this.cache)) {
-                profileUrl = BR.conf.profilesUrl + profileName + '.brf';
+            if (!(profileNameBase in this.cache)) {
+                if (this.profileData.isExternal) {
+                    throw new Error('NYI');
+                } else {
+                    profileUrl = BR.conf.profilesUrl + profileNameBase + '.brf';
+                }
                 loading = true;
                 BR.Util.get(
                     profileUrl,
@@ -68,7 +83,7 @@ BR.Profile = L.Evented.extend({
                     }, this)
                 );
             } else {
-                this._updateProfile(profileName, this.cache[profileName]);
+                this._updateProfile(profileName, this.cache[profileNameBase]);
             }
         }
 
@@ -136,8 +151,10 @@ BR.Profile = L.Evented.extend({
         });
     },
 
-    _buildCustomProfile: function (profileText) {
-        const formValues = this._getFormValues();
+    _buildCustomProfile: function (profileText, formValues) {
+        if (!formValues) {
+            formValues = this._getFormValues();
+        }
         Object.keys(formValues).forEach((name) => {
             const value = formValues[name];
             var re = new RegExp(
@@ -169,13 +186,16 @@ BR.Profile = L.Evented.extend({
 
     _save: function (evt) {
         var profileText = this._buildCustomProfile(this._getProfileText());
-        var that = this;
+        this.profileData.setOptions(this.pendingOptions);
+        this.pendingOptions = {};
+
+        this.profileData._profileText = profileText;
         this.fire('update', {
             profileText: profileText,
-            callback: function (err, profileId, profileText) {
+            callback: (err, profileId, profileText) => {
                 if (!err) {
-                    that.profileName = profileId;
-                    that.cache[profileId] = profileText;
+                    this.profileName = profileId;
+                    this.cache[profileId] = profileText;
                 }
             },
         });
@@ -184,6 +204,17 @@ BR.Profile = L.Evented.extend({
     _updateProfile: function (profileName, profileText) {
         const empty = !this.editor.getValue();
         const clean = this.editor.isClean();
+        this.pendingOptions = {};
+
+        // apply current/initial options
+        profileText = this._buildCustomProfile(profileText, this.profileData.getOptions());
+        if (!this.profileData.isDefault) {
+            // upload the profile to backend
+            // TODO: Currently this happens twice during page load need to fix this
+            this.fire('update', { profileText: profileText });
+        }
+
+        this.profileData._profileText = profileText;
 
         // only synchronize profile editor/parameters with selection if no manual changes in full editor,
         // else keep custom profile pinned - to prevent changes in another profile overwriting previous ones
@@ -236,7 +267,6 @@ BR.Profile = L.Evented.extend({
             var assignRegex = /assign\s*(\w*)\s*=?\s*([\w\.]*)\s*#\s*%(.*)%\s*(\|\s*(.*)\s*\|\s*(.*)\s*)?$/;
             global.forEach(function (item) {
                 var match = item.match(assignRegex);
-                var value;
                 if (match) {
                     var name = match[1];
                     var value = match[2];
@@ -293,7 +323,7 @@ BR.Profile = L.Evented.extend({
             paramsSection.append(i18next.t('sidebar.profile.no_easy_configuration_warning'));
         }
 
-        Object.keys(params).forEach(function (param) {
+        Object.keys(params).forEach((param) => {
             var div = document.createElement('div');
             var label = document.createElement('label');
 
@@ -321,6 +351,9 @@ BR.Profile = L.Evented.extend({
                 label.append(paramName);
                 div.appendChild(label);
                 div.appendChild(select);
+                $(select).on('change', () => {
+                    this.pendingOptions[paramName] = $(select).val();
+                });
             } else {
                 var input = document.createElement('input');
                 input.name = paramName;
@@ -334,6 +367,9 @@ BR.Profile = L.Evented.extend({
                     div.appendChild(label);
                     div.appendChild(input);
                     div.className = 'form-group';
+                    $(input).on('change', () => {
+                        this.pendingOptions[paramName] = $(input).val();
+                    });
                 } else if (paramType == 'boolean') {
                     input.type = 'checkbox';
                     input.checked = params[param].value;
@@ -341,6 +377,9 @@ BR.Profile = L.Evented.extend({
                     div.appendChild(input);
                     label.append(paramName);
                     div.appendChild(label);
+                    $(input).on('change', () => {
+                        this.pendingOptions[paramName] = String($(input).is(':checked'));
+                    });
                 } else {
                     // Unknown parameter type, skip it
                     return;

--- a/js/control/ProfileEditor.js
+++ b/js/control/ProfileEditor.js
@@ -1,4 +1,6 @@
-BR.Profile = L.Evented.extend({
+/* Sidebar for detail edit of profile: Options and free-text
+ * Tightly coupled with ProfileData */
+BR.ProfileEditor = L.Evented.extend({
     cache: {},
     saveWarningShown: false,
     profileData: null,

--- a/js/control/RoutingOptions.js
+++ b/js/control/RoutingOptions.js
@@ -51,7 +51,7 @@ BR.RoutingOptions = L.Evented.extend({
                 if (!profileData.isDefault) {
                     this.setCustomProfile(profileName, true);
                 }
-                this.setOptions({profile: profileName});
+                this.setOptions({ profile: profileName });
             });
             this.on('update', (evt) => {
                 profileData.selectProfile(evt.options.profile);

--- a/js/control/RoutingOptions.js
+++ b/js/control/RoutingOptions.js
@@ -5,7 +5,7 @@ BR.RoutingOptions = L.Evented.extend({
         },
     },
 
-    initialize: function () {
+    initialize: function (profileData) {
         $('#profile-alternative').on('changed.bs.select', this._getChangeHandler());
 
         var remembered_profile = this.getRememberedProfile();
@@ -14,6 +14,16 @@ BR.RoutingOptions = L.Evented.extend({
         // build option list from config
         var profiles = BR.conf.profiles;
         var profiles_list = L.DomUtil.get('profile');
+        // set default value, used as indicator for empty custom profile
+        profiles_list.children[0].value = 'Custom';
+
+        if (!location.hash && remembered_profile) {
+            profileData.selectProfile(remembered_profile);
+            if (!profileData.isDefault) {
+                profiles_list.children[0].value = profileData.toProfileName();
+            }
+        }
+
         for (var i = 0; i < profiles.length; i++) {
             var option = document.createElement('option');
             option.value = profiles[i];
@@ -25,14 +35,28 @@ BR.RoutingOptions = L.Evented.extend({
             }
             profiles_list.appendChild(option);
         }
-        // set default value, used as indicator for empty custom profile
-        profiles_list.children[0].value = 'Custom';
         if (!remembered_profile_was_selected) {
             // <custom> profile is empty at start, select next one
             profiles_list.children[1].selected = true;
         }
 
         L.DomEvent.addListener(document, 'keydown', this._keydownListener, this);
+
+        if (profileData) {
+            if (remembered_profile_was_selected) {
+                profileData.selectProfile(remembered_profile);
+            }
+            profileData.on('changed', () => {
+                let profileName = profileData.toProfileName();
+                if (!profileData.isDefault) {
+                    this.setCustomProfile(profileName, true);
+                }
+                this.setOptions({profile: profileName});
+            });
+            this.on('update', (evt) => {
+                profileData.selectProfile(evt.options.profile);
+            });
+        }
     },
 
     refreshUI: function () {
@@ -79,11 +103,6 @@ BR.RoutingOptions = L.Evented.extend({
         ];
         $('.selectpicker').selectpicker('val', values);
         this.refreshUI();
-
-        if (options.profile && L.BRouter.isCustomProfile(options.profile)) {
-            // custom profile passed with permalink
-            this.setCustomProfile(options.profile, true);
-        }
     },
 
     setCustomProfile: function (profile, noUpdate) {
@@ -105,9 +124,8 @@ BR.RoutingOptions = L.Evented.extend({
             profiles_grp.children[1].selected = true;
         }
 
-        option.selected = !!profile;
-
         if (!noUpdate) {
+            option.selected = !!profile;
             this.fire('update', { options: this.getOptions() });
         }
     },

--- a/js/index.js
+++ b/js/index.js
@@ -27,7 +27,7 @@
             itinerary,
             elevation,
             exportRoute,
-            profile,
+            profileEditor,
             profileData = new BR.ProfileData(),
             trackMessages,
             trackAnalysis,
@@ -233,7 +233,7 @@
         routingOptions.on('update', function (evt) {
             if (urlHash.movingMap) return;
 
-            profile.update(evt.options, () => {
+            profileEditor.update(evt.options, () => {
                 updateRoute(evt);
             });
         });
@@ -261,14 +261,14 @@
 
         elevation = new BR.Heightgraph();
 
-        profile = new BR.Profile(profileData);
-        profile.on('update', function (evt) {
+        profileEditor = new BR.ProfileEditor(profileData);
+        profileEditor.on('update', function (evt) {
             BR.message.hide();
             router.uploadProfile(evt.profileText, function (err, profileId) {
                 if (!err) {
                     updateRoute({});
                 } else {
-                    profile.message.showError(err);
+                    profileEditor.message.showError(err);
                     if (profileId) {
                         router.setOptions(routingOptions.getOptions());
                     }
@@ -281,8 +281,8 @@
             // update url as soon as user saves profile
             urlHash.onMapMove();
         });
-        profile.on('clear', function (evt) {
-            profile.message.hide();
+        profileEditor.on('clear', function (evt) {
+            profileEditor.message.hide();
             this.profileData.selectProfile(null);
         });
         trackMessages = new BR.TrackMessages(map, {
@@ -294,7 +294,7 @@
 
         routingPathQuality = new BR.RoutingPathQuality(map, layersControl);
 
-        routing = new BR.Routing(profile, {
+        routing = new BR.Routing(profileEditor, {
             routing: {
                 router: L.bind(router.getRouteSegment, router),
             },
@@ -303,7 +303,7 @@
 
         pois = new BR.PoiMarkers(routing);
 
-        exportRoute = new BR.Export(router, pois, profile);
+        exportRoute = new BR.Export(router, pois, profileEditor);
 
         routing.on('routing:routeWaypointEnd routing:setWaypointsEnd routing:rerouteSegmentEnd', function (evt) {
             search.clear();
@@ -353,7 +353,7 @@
         sidebar = BR.sidebar({
             defaultTabId: BR.conf.transit ? 'tab_itinerary' : 'tab_profile',
             listeningTabs: {
-                tab_profile: profile,
+                tab_profile: profileEditor,
                 tab_data: trackMessages,
                 tab_analysis: trackAnalysis,
             },
@@ -407,7 +407,7 @@
 
         // (check before hash plugin init)
         if (!location.hash) {
-            profile.update(routingOptions.getOptions());
+            profileEditor.update(routingOptions.getOptions());
 
             // restore active layers from local storage when called without hash
             layersControl.loadActiveLayers();
@@ -438,7 +438,7 @@
             nogos.setOptions(opts);
 
             const optsOrDefault = Object.assign({}, routingOptions.getOptions(), opts);
-            profile.update(optsOrDefault, () => {
+            profileEditor.update(optsOrDefault, () => {
                 if (opts.lonlats) {
                     routing.draw(false);
                     routing.clear();

--- a/js/plugin/Routing.js
+++ b/js/plugin/Routing.js
@@ -42,10 +42,10 @@ BR.Routing = L.Routing.extend({
         },
     },
 
-    initialize: function (profile, options) {
+    initialize: function (profileEditor, options) {
         L.Routing.prototype.initialize.call(this, options);
 
-        this.profile = profile;
+        this.profileEditor = profileEditor;
     },
 
     onAdd: function (map) {
@@ -496,7 +496,7 @@ BR.Routing = L.Routing.extend({
     },
 
     _computeKinematic: function (distance, deltaHeight, costFactor) {
-        const rc = new BR.RoutingContext(this.profile);
+        const rc = new BR.RoutingContext(this.profileEditor);
         rc.expctxWay = new BR.BExpressionContextWay(undefined, costFactor);
         const stdPath = new BR.StdPath();
 

--- a/js/router/BRouter.js
+++ b/js/router/BRouter.js
@@ -16,9 +16,11 @@ L.BRouter = L.Class.extend({
     },
 
     options: {},
+    profileData: null,
 
-    initialize: function (options) {
+    initialize: function (options, profileData) {
         L.setOptions(this, options);
+        this.profileData = profileData;
 
         this.queue = async.queue(
             L.bind(function (task, callback) {
@@ -50,8 +52,6 @@ L.BRouter = L.Class.extend({
         if (this.options.polygons && this._getNogosPolygonsString(this.options.polygons).length > 0)
             params.polygons = this._getNogosPolygonsString(this.options.polygons);
 
-        if (this.options.profile != null) params.profile = this.options.profile;
-
         if (pois && this._getLonLatsNameString(pois) != null) params.pois = this._getLonLatsNameString(pois);
 
         if (circlego) params.circlego = circlego;
@@ -59,16 +59,17 @@ L.BRouter = L.Class.extend({
         params.alternativeidx = this.options.alternative;
 
         if (format != null) {
+            params.profile = this.profileData.id;
             params.format = format;
         } else {
             // do not put values in URL if this is the default value (format===null)
-            if (params.profile === BR.conf.profiles[0]) delete params.profile;
-            if (params.alternativeidx == 0) delete params.alternativeidx;
+            if (!this.profileData.isInitialProfile()) {
+                params.profile = this.profileData.toProfileName();
 
-            // don't add custom profile, as these are only stored temporarily
-            if (params.profile && L.BRouter.isCustomProfile(params.profile)) {
-                delete params.profile;
+                params.profile = encodeURIComponent(params.profile);
             }
+
+            if (params.alternativeidx == 0) delete params.alternativeidx;
         }
 
         return params;
@@ -95,7 +96,7 @@ L.BRouter = L.Class.extend({
             opts.alternative = params.alternativeidx;
         }
         if (params.profile) {
-            opts.profile = this._parseProfile(params.profile);
+            opts.profile = params.profile;
         }
         if (params.pois) {
             opts.pois = this._parseLonLatNames(params.pois);
@@ -143,6 +144,16 @@ L.BRouter = L.Class.extend({
     },
 
     getRoute: function (latLngs, cb) {
+        if (!this.profileData.isDefault && this.profileData.id === L.BRouter.CUSTOM_PREFIX) {
+            // TODO: Known problem because of callback&load order when opening
+            // a url that contains profile with options.
+            // Need to refactor this load order for now use a simple workaround
+            console.warn('Use workaround for not yet availabe profile ID');
+            window.setTimeout(() => {
+                this.getRoute(latLngs, cb);
+            }, 100);
+            return;
+        }
         var url = this.getUrl(latLngs, null, null, null, 'geojson'),
             xhr = new XMLHttpRequest();
 
@@ -193,13 +204,17 @@ L.BRouter = L.Class.extend({
         this.queue.push({ segment: [l1, l2] }, cb);
     },
 
-    uploadProfile: function (profileId, profileText, cb) {
+    uploadProfile: function (profileText, cb) {
         var url = L.BRouter.URL_PROFILE_UPLOAD;
         xhr = new XMLHttpRequest();
 
-        // reuse existing profile file
-        if (profileId) {
-            url += '/' + profileId;
+        if (this.profileData.isDefault) {
+            throw new Error('Unexpected state: Trying to upload default Profile');
+        } else if (this.profileData.id === L.BRouter.CUSTOM_PREFIX) {
+            // custom but first upload
+        } else if (isCustomProfile(this.profileData.id)) {
+            // reuse existing profile file
+            url += '/' + this.profileData.id;
         }
 
         xhr.open('POST', url, true);
@@ -252,6 +267,9 @@ L.BRouter = L.Class.extend({
 
         if (xhr.status === 200 && xhr.responseText && xhr.responseText.length > 0) {
             response = JSON.parse(xhr.responseText);
+            // TODO: the user may have already changed the profile while waiting
+            // for the upload add some validation
+            this.profileData.id = response.profileid;
             cb(response.error, response.profileid);
         } else {
             cb(i18next.t('warning.profile-error'));
@@ -516,6 +534,6 @@ L.BRouter = L.Class.extend({
     },
 });
 
-L.bRouter = function (options) {
-    return new L.BRouter(options);
+L.bRouter = function (options, profileData) {
+    return new L.BRouter(options, profileData);
 };

--- a/js/router/BRouter.js
+++ b/js/router/BRouter.js
@@ -516,14 +516,6 @@ L.BRouter = L.Class.extend({
         return nogos;
     },
 
-    _parseProfile: function (profile) {
-        if (BR.conf.profilesRename?.[profile]) {
-            return BR.conf.profilesRename[profile];
-        }
-
-        return profile;
-    },
-
     // formats L.LatLng object as lng,lat string
     _formatLatLng: function (latLng) {
         var s = '';


### PR DESCRIPTION
Hi!

This is an Idea to address the various issues around this topic. For instance #26 #666 maybe #472
The Idea is to extend the &profile=fastbike value to be itself a nested parameter list. I'am doing this by replacing it with an URI.

The current minimal prototype will create a url like this:
http://localhost:3000/#map=12/51.8751/12.3835/osm-mapnik-german_style,route-quality&lonlats=12.461743,51.882955;12.416908,51.840657&profile=bw%3Afastbike%3Fallow_ferries%3Dfalse
Which when when loaded again will still have the allow_ferries set to false.

I've planed four different formats:
* `<profile-name>` -  just like it is currently when options are not required
* `bw:<profile-name>?<arg>=<value>` - for a standard profile with options
  It's an url with a custom scheme - 'bw:'
* `bwl:local` - for a manually edit profile
  Intention is to show a Message to anyone using the url that the profile is not available
* `http://example.com/profile.brf - for an external profile`
  This is for a future extension: Allowing the user to add custom profiles like they can add custom layers

**Is there any interest in this approach?**

Code wise I've started with creating a new class (ProfileData) to have more centralized state for all this profile related data.
My Intention is to move more of the current processing to this class so the UI-Elements can focus more on the UI part. Hopefully this would allow me to add some unit-tests for this stuff.
Of course this will require a lot of refactoring and likely new bugs. Also it will take quite some time.