### PR TITLE
Support remote GeoJSON layers

### DIFF
--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -349,7 +349,7 @@ BR.LayersConfig = L.Class.extend({
     },
 
     createGeoJsonLayer: function (props) {
-        const layer = L.geoJSON(undefined);
+        const layer = L.geoJSON(undefined, BR.Track.getGeoJsonOptions());
         fetch(props.url).then(async (response) => {
             const geojson = await response.json();
             layer.addData(geojson);

--- a/js/LayersConfig.js
+++ b/js/LayersConfig.js
@@ -348,6 +348,15 @@ BR.LayersConfig = L.Class.extend({
         }
     },
 
+    createGeoJsonLayer: function (props) {
+        const layer = L.geoJSON(undefined);
+        fetch(props.url).then(async (response) => {
+            const geojson = await response.json();
+            layer.addData(geojson);
+        });
+        return layer;
+    },
+
     createLayer: function (layerData) {
         var props = layerData.properties;
         var url = props.url;
@@ -436,6 +445,8 @@ BR.LayersConfig = L.Class.extend({
             layer = this.createOpenStreetMapNotesLayer();
         } else if (props.type === 'mvt') {
             layer = this.createMvtLayer(props, options);
+        } else if (props.type === 'geojson') {
+            layer = this.createGeoJsonLayer(props);
         } else {
             // JOSM
             var josmUrl = url;

--- a/js/util/Track.js
+++ b/js/util/Track.js
@@ -10,13 +10,27 @@ BR.Track = {
      * @returns {Object} to pass as `options` parameter to `L.geoJson`
      */
     getGeoJsonOptions: function (layersControl) {
+        // https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0
+        const styleMapping = [
+            ['stroke', 'color'],
+            ['stroke-width', 'weight'],
+            ['stroke-opacity', 'opacity'],
+            ['fill', 'fillColor'],
+            ['fill-opacity', 'fillOpacity'],
+        ];
         return {
             style: function (geoJsonFeature) {
-                var currentLayerId = layersControl.getActiveBaseLayer().layer.id;
-                return {
+                var currentLayerId = layersControl?.getActiveBaseLayer().layer.id;
+                const featureStyle = {
                     color: currentLayerId === 'cyclosm' ? 'yellow' : 'blue',
                     weight: 4,
                 };
+                for (const [simpleStyle, leafletStyle] of styleMapping) {
+                    if (geoJsonFeature?.properties?.[simpleStyle]) {
+                        featureStyle[leafletStyle] = geoJsonFeature.properties[simpleStyle];
+                    }
+                }
+                return featureStyle;
             },
             interactive: false,
             filter: function (geoJsonFeature) {


### PR DESCRIPTION
I've tried to achieve similar things as #677 and wanted to add a remote GeoJSON as as layer. Currently this seems to be possible using maplibre with a style file which uses a [geojson source](https://maplibre.org/maplibre-style-spec/sources/#geojson). It feels a bit sluggish and comments on leaflet-maplibre mention [performance issues](https://github.com/maplibre/maplibre-gl-leaflet#motivation).

Leaflet also provides GeoJSON support, but it seems there is currently no way to specify them in layer configuration.

I've implemented a minimal version which also support the [simplestyle-spec](https://github.com/mapbox/simplestyle-spec).

To test it you can add a layer configuration which uses the `example.json` from `simplestyle-spec`
```json
{
    "geometry": null,
    "properties": {
        "id": "geojson-simplestyle",
        "overlay": true,
        "type": "geojson",
        "url": "https://raw.githubusercontent.com/mapbox/simplestyle-spec/master/1.1.0/example.geojson"
    },
    "type": "Feature"
}
```

Because I'm not familiar with JS development there's a pending issue: Husky warned me because `fetch` isn't available in all supported browsers. I thought babel & polyfills should take care of that...
