### PR TITLE
Wrap long URLs in custom layers overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -750,6 +750,12 @@ table.dataTable.display tbody tr:hover.selected {
     height: 23px;
 }
 
+.custom_layers_url {
+    word-break: break-all;
+    font-family: monospace;
+    font-size: 0.9rem;
+}
+
 #layers-button-group {
     display: flex;
     justify-content: space-between;

--- a/js/control/Layers.js
+++ b/js/control/Layers.js
@@ -44,7 +44,7 @@ BR.Layers = L.Class.extend({
             },
             columns: [
                 { title: i18next.t('sidebar.layers.table.name') },
-                { title: i18next.t('sidebar.layers.table.URL') },
+                { title: i18next.t('sidebar.layers.table.URL'), className: 'custom_layers_url' },
                 { title: i18next.t('sidebar.layers.table.type') },
             ],
         });


### PR DESCRIPTION
Long URLs were overflowing in the custom layers dialog. This pull request adds a class attribute to the cells of the URL column and uses CSS to wrap those URLs. Additionally, the URLs are printed in a monospace font, but that's for aesthetics only.