### PR TITLE
remove 'msjsdiag.debugger-for-chrome'

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,3 @@
 {
-    "recommendations": [
-        "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint",
-        "ms-azuretools.vscode-docker",
-        "msjsdiag.debugger-for-chrome"
-    ]
+    "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "ms-azuretools.vscode-docker"]
 }


### PR DESCRIPTION
This extension was deprecated as the functionality is now included in VSCode.

see https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome

(file was reformatted by husky/prettyQuick)