### PR TITLE
Adapt voice hints and exporting to changes in BRouter 1.7.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ Copyright (c) 2018 Norbert Renner and [contributors](https://github.com/nrenner/
     Copyright (c) 2012 davidshimjs [The MIT License](https://github.com/llyys/qrcodejs/blob/master/LICENSE)
 -   [Bootstrap Icons](https://github.com/twbs/icons)
     Copyright (c) 2019-2023 The Bootstrap Authors [The MIT License](https://github.com/twbs/icons/blob/main/LICENSE)
+-   [compare-versions](https://github.com/omichelsen/compare-versions)
+    Copyright (c) 2015-2021 Ole Michelsen [The MIT License](https://github.com/omichelsen/compare-versions/blob/main/LICENSE)

--- a/js/format/VoiceHints.js
+++ b/js/format/VoiceHints.js
@@ -203,7 +203,7 @@
         }
     }
 
-    class LocusVoiceHints extends WaypointVoiceHints {
+    class LocusOldVoiceHints extends WaypointVoiceHints {
         _addToTransform(transform) {
             transform.gpx = function (gpx, features) {
                 // hack to insert attribute after the other `xmlns`s
@@ -364,7 +364,10 @@
     BR.voiceHints = function (geoJson, turnInstructionMode, transportMode) {
         switch (turnInstructionMode) {
             case 2:
-                return new LocusVoiceHints(geoJson, turnInstructionMode, transportMode);
+                // TODO:
+                // Use locus-old-style voice hints for now (same style as returned by BRouter 1.6.3
+                // for turnInstructionMode=2), implementation for new-style locus still missing.
+                return new LocusOldVoiceHints(geoJson, turnInstructionMode, transportMode);
             case 3:
                 return new OsmAndVoiceHints(geoJson, turnInstructionMode, transportMode);
             case 4:
@@ -373,6 +376,10 @@
                 return new GpsiesVoiceHints(geoJson, turnInstructionMode, transportMode);
             case 6:
                 return new OruxVoiceHints(geoJson, turnInstructionMode, transportMode);
+            case 7:
+                return new LocusOldVoiceHints(geoJson, turnInstructionMode, transportMode);
+            case 8: // Cruiser export, not exposed in the web UI through profiles yet
+            case 9: // BRouter internal export, not exposed in the web UI through profiles yet
             default:
                 console.error('unhandled turnInstructionMode: ' + turnInstructionMode);
                 return new VoiceHints(geoJson, turnInstructionMode, transportMode);

--- a/js/format/VoiceHints.js
+++ b/js/format/VoiceHints.js
@@ -179,7 +179,7 @@
 
     class GpsiesVoiceHints extends WaypointVoiceHints {
         _getWpt(hint, cmd, coord) {
-            return { name: cmd.message, sym: cmd.symbol.toLowerCase(), type: cmd.symbol };
+            return { name: cmd.message, sym: cmd.symbol?.toLowerCase(), type: cmd.symbol };
         }
     }
 

--- a/js/format/VoiceHints.js
+++ b/js/format/VoiceHints.js
@@ -116,6 +116,7 @@
     // from BRouter btools.router.VoiceHint
     VoiceHints.commands = (function () {
         return {
+            //     Command(name, locus, orux, symbol, fit, message)
             1: new Command('C', 1, 1002, 'Straight', 'straight', 'straight'),
             2: new Command('TL', 4, 1000, 'Left', 'left', 'left'),
             3: new Command('TSLL', 3, 1017, 'TSLL', 'slight_left', 'slight left'),
@@ -125,11 +126,19 @@
             7: new Command('TSHR', 8, 1018, 'TSHR', 'sharp_right', 'sharp right'),
             8: new Command('KL', 9, 1015, 'TSLL', 'left_fork', 'keep left'),
             9: new Command('KR', 10, 1014, 'TSLR', 'right_fork', 'keep right'),
-            10: new Command('TU', 13, 1003, 'TU', 'u_turn', 'u-turn'),
+            // According to getCommandString() in BRouter, Command.name==TU for index TLU
+            // "should be changed to TLU when osmand uses new voice hint constants"
+            // According to getMessageString() in BRouter, Command.message==u-turn for index TLU
+            // "should be changed to u-turn-left when osmand uses new voice hint constants"
+            10: new Command('TU', 13, 1003, 'TU', 'u_turn', 'u-turn'), // Left U-turn
+            // According to getMessageString() in BRouter, Command.message==u-turn for index TRU
+            // "should be changed to u-turn-right when osmand uses new voice hint constants"
             11: new Command('TRU', 14, 1003, 'TU', 'u_turn', 'u-turn'), // Right U-turn
-            12: new Command('OFFR', undefined, undefined, undefined, 'danger', undefined), // Off route
+            12: new Command('OFFR', undefined, undefined, 'OFFR', 'danger', undefined), // Off route
             13: new Command('RNDB', 26, 1008, 'RNDB', 'generic', 'Take exit '), // Roundabout
             14: new Command('RNLB', 26, 1008, 'RNLB', 'generic', 'Take exit '), // Roundabout left
+            15: new Command('TU', 12, 1003, 'TU', 'u_turn', 'u-turn'), // 180 degree u-turn
+            16: new Command('BL', undefined, undefined, 'BL', 'danger', undefined), // Beeline
         };
     })();
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "bootstrap-select": "1.13.18",
         "bootstrap-slider": "11.0.2",
         "codemirror": "5.65.13",
+        "compare-versions": "^6.0.0",
         "core-js-bundle": "3.29.1",
         "datatables": "1.10.18",
         "fit-file-writer": "tbsmark86/fit-file-writer#3eebe13",
@@ -307,6 +308,11 @@
         "url-search-params-polyfill": {
             "main": [
                 "index.js"
+            ]
+        },
+        "compare-versions": {
+            "main": [
+                "lib/umd/index.js"
             ]
         },
         "@mapbox/maki": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4197,6 +4197,11 @@ commander@^9.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
+compare-versions@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.0.0.tgz#a3edb527e4487bfab9a8b62ffe70cebc9b87675b"
+  integrity sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
Patches contained in this series (see commit messages for details), all relating to adapting to changes in BRouter 1.7.0:
- Add BL and TLU to VoiceHints and adapt indexing to BRouter 1.7.0
- Emit console warning when using an unsupported BRouter version
- Document new export formats added in BRouter 1.7.0 and fix export error
- Prevent Gpsies-style export from throwing for undefined symbols

Further changes would be needed (e.g. new Locus format, straight line voice hints, 180° u-turn voice hints at cul-de-sac-style vias, height calculation buffers etc.), but that's all there is for now.

Regarding the new console warning if BRouter is too old, I'm open to better suggestions, of course. I haven't added this new requirement to the [CHANGELOG](https://github.com/nrenner/brouter-web/blob/master/CHANGELOG.md) yet, but it should probably be mentioned there and in the release notes once a new release is tagged. Not sure how increasing the required BRouter version was handled in the past.