### PR TITLE
Unify default max_zoom for custom layers and global maximum zoom

### DIFF
--- a/js/Map.js
+++ b/js/Map.js
@@ -94,13 +94,13 @@ BR.Map = {
         }
         for (i in BR.conf.baseLayers) {
             if (BR.conf.baseLayers.hasOwnProperty(i)) {
-                baseLayers[i] = L.tileLayer(BR.conf.baseLayers[i]);
+                baseLayers[i] = L.tileLayer(BR.conf.baseLayers[i], { maxZoom });
             }
         }
 
         for (i in BR.conf.overlays) {
             if (BR.conf.overlays.hasOwnProperty(i)) {
-                overlays[i] = L.tileLayer(BR.conf.overlays[i]);
+                overlays[i] = L.tileLayer(BR.conf.overlays[i], { maxZoom });
             }
         }
 

--- a/js/control/Layers.js
+++ b/js/control/Layers.js
@@ -121,7 +121,7 @@ BR.Layers = L.Class.extend({
             } else if (dataSource === 'OpenStreetMapNotesAPI') {
                 layer = this._layersControl.layersConfig.createOpenStreetMapNotesLayer();
             } else {
-                layer = L.tileLayer(layerUrl);
+                layer = L.tileLayer(layerUrl, { maxZoom: this._map.getMaxZoom() });
             }
 
             this._customLayers[layerName] = {


### PR DESCRIPTION
Historically, many tile services have been providing tiles up to zoom level 18, with some later enabling zoom levels of 19 and beyond. BRouter-Web's current global limit is 19, which is used by some layers setting `max_zoom` in `/layers/*.geojson`. Tiles added via the custom layers dialog or configured in `/config.js` default to a maximum zoom of 18 due to this being a Leaflet default.

With a custom layer showing and zooming to 19, that layer will be disabled in the layers list. This has two effects:
  - No attempts to fetch any tiles for that level are made, so 404 errors for missing tiles are avoided both for the client and the server.
  - For overlays, the overlay will be hidden. For base layers, gray tiles will be shown to users.

When not disabling custom layers for zoom level 19, it would work like this:
  - Tiles are always fetched, either successfully or with a 404 error.
  - Tiles will be shown to the user if available, and replaced with a gray tile otherwise.

Essentially there is a tradeoff between trying to avoid unsuccessful tile fetches and impacting the user experience. By making the tradeoff less conservative, tiles will be shown to users in more cases, at the expense of more 404 errors (but luckily no change in user experience) for servers not supporting level 19. Note that we already cause 404 errors for services not even supporting 18, as the limit of 18 is a best guess only anyway.

Given those considerations and the trend for more and more services to provide level 19 tiles, here we unify the global limit of 19 and the limit for custom layers (more precisely: any layer not having explicitly specified another `max_zoom`). This prioritizes user experience over overly cautious tile fetches.

This change can be considered a temporary measure. In the future, the global default in Leaflet could be increased, and in BRouter-Web custom zoom limits, auto-detection and up-scaling could be hooked up.

Fixes #726.

Test Plan:
  - Add a map supporting only level 18 tiles via "More" and via "Custom layers", e.g. "OpenStreetMap (Belgian Style)".
  - Add a map also supporting level 19 tiles via "More" and via "Custom layers", e.g. "OpenStreetMap".
  - For each map, zoom to level 19.
  - There will still be gray tiles (and some additional 404 errors in the browser console) for the custom "OpenStreetMap (Belgian Style)" map.
  - The pre-configured "OpenStreetMap (Belgian Style)" map still up-scales.
  - Now the custom "OpenStreetMap" map will show without gray tiles, while before only the pre-configured map worked.
  - Test that not only layers added via the custom layers dialog show the new behaviour, but those configured in `/config.js` (both base layers and overlays) and those from `/layers/*.geojson` without an explicit `max_zoom` as well.
  - Check that the global zoom limit of 19 still applies.