### PR TITLE
Route analysis: Only highlight actual tracks for a given tracktype

### DIFF
--- a/js/control/TrackAnalysis.js
+++ b/js/control/TrackAnalysis.js
@@ -544,8 +544,8 @@ BR.TrackAnalysis = L.Class.extend({
 
         switch (dataType) {
             case 'highway':
-                if (dataName === 'track') {
-                    if (trackType === 'unknown' && parsed.highway === 'track' && !parsed.tracktype) {
+                if (dataName === 'track' && parsed.highway === 'track') {
+                    if (trackType === 'unknown' && !parsed.tracktype) {
                         return true;
                     }
 


### PR DESCRIPTION
In the OSM data model, a tracktype (e.g. "Grade1") can be set for highways other than tracks (e.g. "Unclassified" roads) too. However, in the route analysis sidebar categories are exclusive, i.e. there are separate categories per tracktype for "track" highways, but for other highways all tracktypes are summarized into a single category.

This separation already works fine for the resulting table, but when highlighting a category on the map by clicking on the respective table row, highways other than tracks could be marked too in case they had a tracktype assigned.

When trying to match a particular highway on the map to a given tracktype in `wayTagsMatchesData(...)`, it is needed to check if that highway is actually a highway of category "track". Currently that check is only done for "unknown" tracktypes, but is missing for all other tracktypes.

By adding the missing check, the issue can be resolved. It is enough to move the check to the outer `if` instead of duplicating it, since the later generic `return` will be `false` due to `parsed.highway===dataName` evaluating to `false` in that case anyway.

Fixes #768.

Test Plan:
  - Open a route with at least one `highway=track` with a known `tracktype`, and at least one `highway` of another category, but with the same `tracktype` (e.g. from the linked issue).
  - In the route analysis sidebar in the highways table, select the track with that `tracktype`. Only the track should be highlighted, but not the other highway with the same `tracktype`.
   - Select the category of the other highway. The corresponding highway on the map should still be highlighted.