### PR TITLE
Enable "Edit" link in attribution for openstreetmap.org map layer

### DIFF
--- a/js/Map.js
+++ b/js/Map.js
@@ -21,6 +21,7 @@ BR.Map = {
             worldCopyJump: true,
             minZoom: 0,
             maxZoom: maxZoom,
+            attributionEditLink: true,
         });
 
         if (BR.Util.getResponsiveBreakpoint() >= '3md') {


### PR DESCRIPTION
Currently in the lower right of the map there is an attribution link, which for the "OpenStreetMap" base layer opens a new tab with osm.org at the current location. Only after navigating to osm.org there is then a way for users to contribute back to OSM, i.e. edit the map, which is essential in the long-term for both BRouter-Web's (maps) and BRouter's (routing data) success too.

To make it more obvious that users are allowed and encouraged to contribute to OSM, here we add another link called "Edit", which hopefully will make users curious and entice them to click on it. Clicking on the link will result in osm.org opening in a new tab too, but this time in edit mode. If not logged in, users will be prompted to log in or sign up. If logged in, the web-based iD editor will start immediately.

Note that the value proposition of that button is not so much in linking to osm.org (we already do that), but that it is clearly labeled "Edit" (getting users interested / making them aware) and that it only appears on osm.org, but not e.g. for "Esri World Imagery" which cannot be edited anyway.

In addition, the link saves an extra click compared to opening osm.org in non-edit mode first and having to separately click on "Edit". Under osm.org's "My Preferences" > "Edit Preferences" it is even possible to configure a default editor when logged in, so clicking on the "Edit" link in BRouter-Web would change e.g. JOSM's current viewport via its "Remote Control" interface immediately, no extra clicks needed (apart from closing/switching away from the new/updated osm.org tab again, admittedly).

The target audience for the link are occasional and novice OSM users. Power users should use browser addons like "OSM Smart Menu" to quickly switch between map products/sites. A more elaborate "Contribute to the map" menu/popup could be added later.

Implementation-wise, the functionality is already present in the attribution control we embed from "MapBBCode/mapbbcode", we only need to enable it. Supporting more OSM-based maps in the "Edit" link would need to be implemented in "mapbbcode", it should probably evaluate `"category": "osmbasedmap"` as found in `layers/*.geojson` and/or match on more URLs.

Relates to #403 and #694.

Test Plan:
  - Log into osm.org.
  - In BRouter-Web, change to the "OpenStreetMap" base layer and click on "Edit".
  - The iD editor (if configured as default) should open at the current location in osm.org.
  - Change to a different base layer. The "Edit" link should get removed.
  - Duplicate `standard.geojson`. Enabling it as an overlay should also trigger the "Edit" link, but there should only be a single "Edit" link if both overlay and base map are active at the same time.