### PR TITLE
Enable sharing via Mastodon

### DIFF
--- a/js/control/ShareRoute.js
+++ b/js/control/ShareRoute.js
@@ -1,12 +1,7 @@
 BR.ShareRoute = L.Class.extend({
-    /**
-     * Sharing via Mastodon is currently disabled by default, because
-     * the share intent fails when the current route URL is longer
-     * than the post character limit for that instance.
-     */
     options: {
         services: {
-            mastodon: false,
+            mastodon: true,
         },
         shortcut: {
             share_action: 65, // char code for 'a' ("action")


### PR DESCRIPTION
Sharing works now with newer Mastodon releases.

<img width="868" alt="SCR-20231007-mjtx" src="https://github.com/nrenner/brouter-web/assets/328130/855c2a1f-c7e2-47d1-b0d3-cc1163a7c40f">

<img width="495" alt="SCR-20231007-mkaj" src="https://github.com/nrenner/brouter-web/assets/328130/e2273a9b-3ed4-460b-9572-4ed09bfebe97">
