### PR TITLE
Change IGNF layers URLs

### DIFF
--- a/keys.template.js
+++ b/keys.template.js
@@ -20,7 +20,7 @@
         // Mapillary, https://www.mapillary.com/dashboard/developers
         mapillary: ``,
 
-        // IGN France (for Scan25 base layer), https://geoservices.ign.fr/services-web-issus-des-scans-ign
+        // IGN France (for Scan25 base layer), https://geoservices.ign.fr/actualites/2023-11-20-acces-donnesnonlibres-gpf
         ignf: '',
     };
 })();

--- a/layers/extra/ignf-aerial.geojson
+++ b/layers/extra/ignf-aerial.geojson
@@ -8,7 +8,7 @@
         "max_zoom": 21,
         "name": "IGN France - Photographies aériennes",
         "type": "tms",
-        "url": "https://wxs.ign.fr/ortho/geoportail/wmts?LAYER=ORTHOIMAGERY.ORTHOPHOTOS&EXCEPTIONS=text/xml&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+        "url": "https://data.geopf.fr/wmts?LAYER=ORTHOIMAGERY.ORTHOPHOTOS&EXCEPTIONS=text/xml&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
     },
     "type": "Feature"
 }

--- a/layers/extra/ignf-map.geojson
+++ b/layers/extra/ignf-map.geojson
@@ -8,7 +8,7 @@
         "max_zoom": 21,
         "name": "IGN France - Plan IGN",
         "type": "tms",
-        "url": "https://wxs.ign.fr/cartes/geoportail/wmts?LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&EXCEPTIONS=text/xml&FORMAT=image/png&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+        "url": "https://data.geopf.fr/wmts?LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&EXCEPTIONS=text/xml&FORMAT=image/png&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
     },
     "type": "Feature"
 }

--- a/layers/extra/ignf-scan25.geojson
+++ b/layers/extra/ignf-scan25.geojson
@@ -8,7 +8,7 @@
         "max_zoom": 21,
         "name": "IGN France - Carte topographique (Scan25)",
         "type": "tms",
-        "url": "https://wxs.ign.fr/{keys_ignf}/geoportail/wmts?LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR&EXCEPTIONS=text/xml&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+        "url": "https://data.geopf.fr/private/wmts?LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR&EXCEPTIONS=text/xml&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&apikey={keys_ignf}&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
     },
     "type": "Feature"
 }


### PR DESCRIPTION
Change urls from wxs.ign.fr to data.geopf.fr for IGNF layers

The old urls will stop working on March 15th 2024 (according to https://geoservices.ign.fr/bascule-vers-la-geoplateforme in french)

There is a publicly available sample `apikey` parameter for testing the *ignf-scan25* layer: '`ign_scan_ws`' (https://geoservices.ign.fr/actualites/2023-11-20-acces-donnesnonlibres-gpf in french)

These changes maintain the layers added by #636 and #643