### PR TITLE
add 'break' to switch to prevent fall-through

### DIFF
--- a/js/plugin/RoutingPathQuality.js
+++ b/js/plugin/RoutingPathQuality.js
@@ -103,6 +103,7 @@ BR.RoutingPathQuality = L.Control.extend({
                                 case 'concrete:lanes':
                                 case 'concrete:plates':
                                     surface = 0.6;
+                                    break;
                                 case 'sett':
                                 case 'gravel':
                                 case 'pebblestone':


### PR DESCRIPTION
A missing break lead to fall-through in the switch statement.