### PR TITLE
add overpass query for railway station

### DIFF
--- a/layers/config/tree.js
+++ b/layers/config/tree.js
@@ -146,6 +146,7 @@ BR.confLayers.tree = {
                 'parking_entrance',
                 'parking',
                 'parking_space',
+                'railway_station',
                 'taxi',
                 'vehicle_inspection',
             ]

--- a/layers/overpass/amenity/transportation/railway_station.geojson
+++ b/layers/overpass/amenity/transportation/railway_station.geojson
@@ -1,0 +1,13 @@
+{
+    "geometry": null,
+    "properties": {
+      "name": "Railway station",
+      "id": "railway_station",
+      "overlay": true,
+      "dataSource": "OverpassAPI",
+      "icon": "temaki-train",
+      "query": "nwr[railway=station];"
+    },
+    "type": "Feature"
+  }
+  

--- a/package.json
+++ b/package.json
@@ -367,7 +367,8 @@
                 "icons/museum.svg",
                 "icons/spotting_scope.svg",
                 "icons/cabin.svg",
-                "icons/picnic_shelter.svg"
+                "icons/picnic_shelter.svg",
+                "icons/train.svg"
             ]
         },
         "@fortawesome/fontawesome-free": {


### PR DESCRIPTION
This PR adds the Overpass query for railway stations to the transportation layers.

I'm adding the overpass query regularly, because it's currently missing and I think, it should be available by default.