### PR TITLE
Update leaflet to 1.9.4

### DIFF
--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -96,7 +96,7 @@ BR.NogoAreas = L.Control.extend({
         });
 
         // prevent instant re-activate when turning off button by both Pointer and Click
-        // events firing in Chrome mobile while L.Map.Tap enabled for circle drawing
+        // events firing in Chrome mobile while L.Map.TapHold enabled for circle drawing
         L.DomEvent.addListener(this.button.button, 'pointerdown', L.DomEvent.stop);
 
         L.DomEvent.addListener(document, 'keydown', this._keydownListener, this);
@@ -424,25 +424,25 @@ BR.NogoAreas = L.Control.extend({
 BR.NogoAreas.include(L.Evented.prototype);
 
 BR.Editable = L.Editable.extend({
-    // Editable relies on L.Map.Tap for touch support. But the Tap handler is not added when
+    // Editable relies on L.Map.TapHold for touch support. But the TapHold handler is not added when
     // the Browser supports Pointer events, which is the case for mobile Chrome. So we add it
     // ourselves in this case, but disabled and only enable while drawing (#259).
-    // Also, we generally disable the Tap handler in the map options for route dragging,
+    // Also, we generally disable the TapHold handler in the map options for route dragging,
     // see Map.js, so we always need to enable for drawing.
 
     initialize: function (map, options) {
         L.Editable.prototype.initialize.call(this, map, options);
 
-        if (!this.map.tap) {
-            this.map.addHandler('tap', L.Map.Tap);
-            this.map.tap.disable();
+        if (!this.map.tapHold) {
+            this.map.addHandler('tapHold', L.Map.TapHold);
+            this.map.tapHold.disable();
         }
     },
 
     registerForDrawing: function (editor) {
-        this._tapEnabled = this.map.tap.enabled();
+        this._tapEnabled = this.map.tapHold.enabled();
         if (!this._tapEnabled) {
-            this.map.tap.enable();
+            this.map.tapHold.enable();
         }
 
         L.Editable.prototype.registerForDrawing.call(this, editor);
@@ -450,7 +450,7 @@ BR.Editable = L.Editable.extend({
 
     unregisterForDrawing: function (editor) {
         if (!this._tapEnabled) {
-            this.map.tap.disable();
+            this.map.tapHold.disable();
         }
 
         L.Editable.prototype.unregisterForDrawing.call(this, editor);

--- a/js/plugin/NogoAreas.js
+++ b/js/plugin/NogoAreas.js
@@ -513,7 +513,7 @@ BR.EditingTooltip = L.Handler.extend({
                     0.5 * (layer.getBounds().getWest() + layer.getBounds().getEast())
                 );
             }
-            L.Layer.prototype.openTooltip.call(this, layer, latlng);
+            L.Layer.prototype.openTooltip.call(this, latlng);
         };
     },
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "jquery": "3.6.4",
         "jquery-i18next": "1.2.1",
         "jstree": "3.3.12",
-        "leaflet": "1.7.1",
+        "leaflet": "1.9.4",
         "leaflet-control-geocoder": "2.4.0",
         "leaflet-easybutton": "*",
         "leaflet-editable": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7716,12 +7716,7 @@ leaflet.stravasegments@2.3.2:
     leaflet-easybutton "^2.3.0"
     leaflet-triangle-marker "^1.0.1"
 
-leaflet@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
-  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
-
-leaflet@^1.0.1, leaflet@^1.3.4, leaflet@^1.5.0, leaflet@^1.6.0:
+leaflet@1.9.4, leaflet@^1.0.1, leaflet@^1.3.4, leaflet@^1.5.0, leaflet@^1.6.0:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
   integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==


### PR DESCRIPTION
This is a starting point to update Leaflet to the most recent version (solves #792).

I managed to fix the most obvious issue with the no-go-area. They are usable.

However, there is still one exception on the browser console that I couldn't solve so far.
![leaflet-nogo-areas](https://github.com/user-attachments/assets/89736495-3b4f-4a58-9a80-0a790128b9bd)

Maybe someone else is able to fix it.