### PR TITLE
allow additional GeoJSON MIME type

### DIFF
--- a/js/router/BRouter.js
+++ b/js/router/BRouter.js
@@ -171,7 +171,8 @@ L.BRouter = L.Class.extend({
             xhr.status === 200 &&
             xhr.responseText &&
             // application error when not GeoJSON format (text/plain for errors)
-            xhr.getResponseHeader('Content-Type').split(';')[0] === 'application/vnd.geo+json'
+            (xhr.getResponseHeader('Content-Type').split(';')[0] === 'application/geo+json' ||
+                xhr.getResponseHeader('Content-Type').split(';')[0] === 'application/vnd.geo+json')
         ) {
             // leaflet.spin
             //gpxLayer.fire('data:loaded');


### PR DESCRIPTION
The MIME type for GeoJSON registered with IANA is `application/geo+json`, replacing the old value `application/vnd.geo+json`. The change was published with RFC 7946 in 2016.

BRouter reponses changed to `application/geo+json` in recent versions.

With this commit BRouter-Web accepts either of both MIME type strings in BRouter responses.