### PR TITLE
Add “Maximum Speed” to analysis sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -350,10 +350,6 @@ table.dataTable.track-analysis-table tfoot td {
     padding-top: 4px;
 }
 
-.track-analysis-title {
-    text-transform: capitalize;
-}
-
 .track-analysis-distance {
     text-align: right;
 }

--- a/js/control/TrackAnalysis.js
+++ b/js/control/TrackAnalysis.js
@@ -180,13 +180,19 @@ BR.TrackAnalysis = L.Class.extend({
                         case 'surface':
                         case 'smoothness':
                             if (typeof analysis[tagName][wayTagParts[1]] === 'undefined') {
-                                let formattedName = i18next.t([
-                                    'sidebar.analysis.data.' + tagName + '.' + wayTagParts[1],
-                                    wayTagParts[1],
-                                ]);
+                                let formattedName;
+
                                 if (tagName.indexOf('maxspeed') === 0) {
-                                    formattedName += ' km/h';
+                                    formattedName = i18next.t('sidebar.analysis.data.maxspeed', {
+                                        maxspeed: wayTagParts[1],
+                                    });
+                                } else {
+                                    formattedName = i18next.t([
+                                        'sidebar.analysis.data.' + tagName + '.' + wayTagParts[1],
+                                        wayTagParts[1],
+                                    ]);
                                 }
+
                                 analysis[tagName][wayTagParts[1]] = {
                                     formatted_name: formattedName,
                                     name: wayTagParts[1],

--- a/js/control/TrackAnalysis.js
+++ b/js/control/TrackAnalysis.js
@@ -82,7 +82,7 @@ BR.TrackAnalysis = L.Class.extend({
      *   table row for highlighting matching track segments
      *
      * @param {Polyline} polyline
-     * @param {Array} segments route segments between waypoints
+     * @param {Array} segments - route segments between waypoints
      */
     update(polyline, segments) {
         if (!this.active) {
@@ -219,8 +219,8 @@ BR.TrackAnalysis = L.Class.extend({
      * `maxspeed:backward`. Depending on the existence of the `reversedirection` field
      * we can select the correct value.
      *
-     * @param wayTags tags + values for a way segment
-     * @param routingType currently only 'cycling' is supported, can be extended in the future (walking, driving, etc.)
+     * @param wayTags - tags + values for a way segment
+     * @param routingType - currently only 'cycling' is supported, can be extended in the future (walking, driving, etc.)
      * @returns {*[]}
      */
     normalizeWayTags(wayTags, routingType) {
@@ -502,9 +502,9 @@ BR.TrackAnalysis = L.Class.extend({
      * track edge matches the search, create a Leaflet polyline
      * and add it to the result array.
      *
-     * @param {string} dataType `highway`, `surface`, `smoothness`
-     * @param {string} dataName `primary`, `track, `asphalt`, etc.
-     * @param {string} trackType the tracktype is passed here (e.g.
+     * @param {string} dataType - `highway`, `surface`, `smoothness`
+     * @param {string} dataName - `primary`, `track, `asphalt`, etc.
+     * @param {string} trackType - the tracktype is passed here (e.g.
      * `grade3`), but only in the case that `dataName` is `track`
      *
      * @returns {Polyline[]}
@@ -535,11 +535,11 @@ BR.TrackAnalysis = L.Class.extend({
      * which matches if a tag-pair is missing. Special handling for
      * tracktypes again.
      *
-     * @param {string} wayTags The way tags as provided by brouter, e.g.
+     * @param {string} wayTags - The way tags as provided by brouter, e.g.
      * `highway=secondary surface=asphalt smoothness=good`
-     * @param {string} dataType `highway`, `surface`, `smoothness`
-     * @param {string} dataName `primary`, `track, `asphalt`, etc.
-     * @param {string} trackType the tracktype is passed here (e.g.
+     * @param {string} dataType - `highway`, `surface`, `smoothness`
+     * @param {string} dataName - `primary`, `track, `asphalt`, etc.
+     * @param {string} trackType - the tracktype is passed here (e.g.
      * `grade3`), but only in the case that `dataName` is `track`
      *
      * @returns {boolean}
@@ -616,7 +616,7 @@ BR.TrackAnalysis = L.Class.extend({
      *
      * 'highway=primary surface=asphalt' => { highway: 'primary', surface: 'asphalt' }
      *
-     * @param wayTags The way tags as provided by brouter, e.g.
+     * @param wayTags - The way tags as provided by brouter, e.g.
      * `highway=secondary surface=asphalt smoothness=good`
      *
      * @returns {object}
@@ -638,7 +638,7 @@ BR.TrackAnalysis = L.Class.extend({
      *
      * { 'highway' : 'path', 'surface' : 'sand' } => ['highway=path', 'surface=sand']
      *
-     * @param wayTags The way tags in object representation
+     * @param wayTags - The way tags in object representation
      *
      * @returns {object}
      */

--- a/locales/en.json
+++ b/locales/en.json
@@ -338,7 +338,8 @@
                 "horrible": "Horrible",
                 "very_horrible": "Very Horrible",
                 "impassable": "Impassable"
-            }
+            },
+            "maxspeed": "{{maxspeed}} km/h"
         },
       "header": {
         "highway": "Highway",

--- a/locales/en.json
+++ b/locales/en.json
@@ -285,10 +285,66 @@
   },
   "sidebar": {
     "analysis": {
+        "data": {
+            "highway": {
+                "footway": "Footway",
+                "path": "Path",
+                "residential": "Residential",
+                "cycleway": "Cycleway",
+                "track": "Track",
+                "service": "Service",
+                "tertiary": "Tertiary",
+                "secondary": "Secondary",
+                "primary": "Primary",
+                "trunk": "Trunk",
+                "motorway": "Motorway",
+                "motorway_link": "Motorway Link",
+                "primary_link": "Primary Link",
+                "secondary_link": "Secondary Link",
+                "tertiary_link": "Tertiary Link",
+                "trunk_link": "Trunk Link",
+                "living_street": "Living Street",
+                "pedestrian": "Pedestrian",
+                "road": "Road",
+                "bridleway": "Bridleway",
+                "steps": "Steps",
+                "sidewalk": "Sidewalk",
+                "crossing": "Crossing",
+                "unclassified": "Unclassified"
+            },
+            "surface": {
+                "asphalt": "Asphalt",
+                "cobblestone": "Cobblestone",
+                "compacted": "Compacted",
+                "dirt": "Dirt",
+                "fine_gravel": "Fine Gravel",
+                "grass": "Grass",
+                "gravel": "Gravel",
+                "ground": "Ground",
+                "paved": "Paved",
+                "sand": "Sand",
+                "unpaved": "Unpaved",
+                "wood": "Wood",
+                "concrete": "Concrete",
+                "paving_stones": "Paving Stones",
+                "sett": "Sett"
+            },
+            "smoothness": {
+                "excellent": "Excellent",
+                "good": "Good",
+                "intermediate": "Intermediate",
+                "bad": "Bad",
+                "very_bad": "Very Bad",
+                "horrible": "Horrible",
+                "very_horrible": "Very Horrible",
+                "impassable": "Impassable"
+            }
+        },
       "header": {
         "highway": "Highway",
         "smoothness": "Smoothness",
-        "surface": "Surface"
+        "surface": "Surface",
+        "maxspeed": "Maximum Speed"
       },
       "table": {
         "category": "Category",


### PR DESCRIPTION
It shows the distribution of maximum speeds for all ways on the current route (if that data is available, otherwise it’s summed up under “unknown”).

`maxspeed:forward` and `maxspeed:backward` is respected in conjunction with `reversedirection`.

Hovering/clicking table rows to highlight matching segments on the route work the identical to the other analysis tables.

Additionally, all tags in the analysis tab (way type, surface, smoothness) are translateable now. The values were added to `en.json`.

Some HTML is rendered with template literals now, instead of concatenating strings.

Variable declarations were changed from `var` to `const`/`let`.