### PR TITLE
Fix URL for calling OSM

### DIFF
--- a/layers/config/overrides.js
+++ b/layers/config/overrides.js
@@ -70,9 +70,9 @@ BR.confLayers.getPropertyOverrides = function() {
             'name': i18next.t('map.layer.osmde'),
             'language_code': 'de',
             'attribution': {
-                'html': '&copy; <a target="_blank" href="https://openstreetmap.de/karte.html">openstreetmap.de</a>'
+                'html': '&copy; <a target="_blank" href="https://openstreetmap.de/karte">openstreetmap.de</a>'
             },
-            'mapUrl': 'https://www.openstreetmap.de/karte.html?zoom={zoom}&lat={lat}&lon={lon}&layers=B000TF'
+            'mapUrl': 'https://www.openstreetmap.de/karte?zoom={zoom}&lat={lat}&lon={lon}&layers=B000TF'
         },
         'osmfr': {
             'language_code': 'fr',


### PR DESCRIPTION
The OSM URL in the bottom right-hand corner contains "karte.html" in the path. If the link is called, OSM throws away the ".html" part and redirects to the start page without parameters.

In order for the parameters to be properly adopted by OSM, the URL would have to be "https://www.openstreetmap.de/karte?zoom=12&lat=53.5138&lon=7.8207&layers=B000TF", for example.